### PR TITLE
Bump Kubeflow Central Dashboard to v2.0.0 GA

### DIFF
--- a/kubeflow/charts/kubeflow-dashboard/Chart.yaml
+++ b/kubeflow/charts/kubeflow-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v2.0.0-rc.1
+appVersion: v2.0.0
 description: Kubeflow Central Dashboard
 name: kubeflow-dashboard
 type: application

--- a/kubeflow/charts/kubeflow-dashboard/values.yaml
+++ b/kubeflow/charts/kubeflow-dashboard/values.yaml
@@ -2,7 +2,7 @@ namespace: kubeflow
 
 image:
   repository: ghcr.io/kubeflow/dashboard/dashboard
-  tag: v2.0.0-rc.1
+  tag: v2.0.0
 
 userid_header: kubeflow-userid
 userid_prefix: ""

--- a/kubeflow/terraform/main.tf
+++ b/kubeflow/terraform/main.tf
@@ -318,7 +318,7 @@ resource "helm_release" "kubeflow_dashboard" {
       namespace = kubernetes_namespace.kubeflow.metadata[0].name
       image = {
         repository = "ghcr.io/kubeflow/dashboard/dashboard"
-        tag        = "v2.0.0-rc.1"
+        tag        = "v2.0.0"
       }
       userid_header     = "X-Forwarded-Email"
       registration_flow = "false"


### PR DESCRIPTION
## Summary
- Bump the Kubeflow Central Dashboard image from `v2.0.0-rc.1` to GA `v2.0.0`.
- Updates `kubeflow/charts/kubeflow-dashboard/values.yaml` (`image.tag`) and `Chart.yaml` (`appVersion`).
- Also updates the terraform `helm_release.kubeflow_dashboard` override in `kubeflow/terraform/main.tf`, which was pinning the tag back to `rc.1` at deploy time — without this, the chart bump alone would not have taken effect.

Note: `kubeflow-profiles` is intentionally left on `rc.1` (separate component). Closes platform-7at (part of #158).

## Test plan
- [ ] `terraform plan` shows only the dashboard image tag change
- [ ] After apply, dashboard pod rolls out healthy on `v2.0.0`
- [ ] Central dashboard UI is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)