### PR TITLE
Bump Kubeflow Profiles + KFAM to v2.0.0 GA

### DIFF
--- a/kubeflow/charts/kubeflow-profiles/Chart.yaml
+++ b/kubeflow/charts/kubeflow-profiles/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v2.0.0-rc.1
+appVersion: v2.0.0
 description: Kubeflow Profile controller and KFAM (access management) API
 name: kubeflow-profiles
 type: application

--- a/kubeflow/charts/kubeflow-profiles/values.yaml
+++ b/kubeflow/charts/kubeflow-profiles/values.yaml
@@ -1,6 +1,6 @@
 namespace: kubeflow
 
-image_tag: v2.0.0-rc.1
+image_tag: v2.0.0
 kfam_image: ghcr.io/kubeflow/dashboard/access-management
 controller_image: ghcr.io/kubeflow/dashboard/profile-controller
 

--- a/kubeflow/terraform/main.tf
+++ b/kubeflow/terraform/main.tf
@@ -294,7 +294,7 @@ resource "helm_release" "kubeflow_profiles" {
   values = [
     yamlencode({
       namespace               = kubernetes_namespace.kubeflow.metadata[0].name
-      image_tag               = "v2.0.0-rc.1"
+      image_tag               = "v2.0.0"
       admin_email             = var.admin_email
       admin_profile_namespace = local.admin_profile_namespace
       userid_header           = "X-Forwarded-Email"


### PR DESCRIPTION
## Summary
- Bump `kubeflow-profiles` (profile-controller + KFAM) off the release candidate to GA.
- `values.yaml` `image_tag` and `Chart.yaml` `appVersion`: `v2.0.0-rc.1` → `v2.0.0`.
- `kubeflow/terraform/main.tf:297` `helm_release.kubeflow_profiles` `image_tag` override updated to `v2.0.0` (otherwise it re-pins the deployed tag to rc.1).

Closes bead `platform-3m9`; part of #158. Sibling of the dashboard GA bump (#186).

## Test plan
- [ ] `terraform plan` shows only the image_tag change for `kubeflow_profiles`.
- [ ] After apply, `profile-controller` and `kfam` pods roll out healthy.
- [ ] Per-namespace profile reconciliation still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)