### PR TITLE
Bump KFP profile-controller image and Training Operator to v1.9.3

### DIFF
--- a/kubeflow/charts/pipelines/templates/deployments.yaml
+++ b/kubeflow/charts/pipelines/templates/deployments.yaml
@@ -176,7 +176,7 @@ spec:
         envFrom:
         - configMapRef:
             name: kubeflow-pipelines-profile-controller-env
-        image: python:3.9
+        image: docker.io/alpine/k8s:1.32.3
         name: profile-controller
         ports:
         - containerPort: 8080

--- a/kubeflow/charts/pipelines/templates/deployments.yaml
+++ b/kubeflow/charts/pipelines/templates/deployments.yaml
@@ -176,6 +176,8 @@ spec:
         envFrom:
         - configMapRef:
             name: kubeflow-pipelines-profile-controller-env
+        # Image must provide a Python interpreter: the command runs `python /hooks/sync.py`.
+        # alpine/k8s bundles aws-cli v1 (Python), so python3 is present. Matches upstream KFP 2.16.1.
         image: docker.io/alpine/k8s:1.32.3
         name: profile-controller
         ports:

--- a/kubeflow/charts/pipelines/templates/deployments.yaml
+++ b/kubeflow/charts/pipelines/templates/deployments.yaml
@@ -178,7 +178,7 @@ spec:
             name: kubeflow-pipelines-profile-controller-env
         # Image must provide a Python interpreter: the command runs `python /hooks/sync.py`.
         # alpine/k8s bundles aws-cli v1 (Python), so python3 is present. Matches upstream KFP 2.16.1.
-        image: docker.io/alpine/k8s:1.32.3
+        image: docker.io/alpine/k8s:1.32.3@sha256:eec3541331932d8613ce7b3283508063cba7f704302e9b4eda45e49b38a2a0f9
         name: profile-controller
         ports:
         - containerPort: 8080

--- a/kubeflow/charts/training-operator/Chart.yaml
+++ b/kubeflow/charts/training-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v1.8.0"
+appVersion: "v1.9.3"
 description: A Helm chart for Kubeflow training-operator
 name: kubeflow-training-operator
-version: 1.0.5
+version: 1.0.6

--- a/kubeflow/charts/training-operator/templates/deployment.yaml
+++ b/kubeflow/charts/training-operator/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - command:
             - /manager
-          image: ghcr.io/kubeflow/training-v1/training-operator:v1-d6eb98e
+          image: ghcr.io/kubeflow/training-v1/training-operator:v1-d6eb98e@sha256:63856299c038d219e9bc844e8689003bef4974b603fa54408c63880406df4be8
           name: training-operator
           ports:
             - containerPort: 8080

--- a/kubeflow/charts/training-operator/templates/deployment.yaml
+++ b/kubeflow/charts/training-operator/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - command:
             - /manager
-          image: kubeflow/training-operator:v1-be2e29e
+          image: ghcr.io/kubeflow/training-v1/training-operator:v1-d6eb98e
           name: training-operator
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary
- Swap the Kubeflow Pipelines `profile-controller` container image `python:3.9` → `docker.io/alpine/k8s:1.32.3`, matching what KFP 2.16.1 ships (python:3.9 is EOL since Oct 2025). MinIO env wiring and the `sync.py` ConfigMap are unchanged.
- Bump Kubeflow Training Operator `v1.8.0` → `v1.9.3` (Option A from `platform-rp2`): patch within the v1 line, same architecture. Image registry moved to the GHCR legacy-v1 line (`ghcr.io/kubeflow/training-v1/training-operator:v1-d6eb98e`) under the renamed `kubeflow/trainer` repo. CRDs already at the v1.9.3 generation, so no CRD changes were needed.
- Pin both changed images by digest (`tag@sha256:…`, tags retained for readability) so deploys are reproducible and the mutable-tag supply-chain gap is closed.

## Context
- These continue the component-currency work tracked under GitHub issue #158.
- The v2.2.1 Kubeflow Trainer migration (new `TrainJob`/`TrainingRuntime` CRDs) is deliberately deferred and tracked in beads `platform-ce7`.
- Non-root `securityContext` hardening for the profile-controller is tracked in beads `platform-29g`.
- A CI `helm lint`/`helm template` check for these charts is tracked in beads `platform-olw`.

## Test plan
- [ ] `helm template` renders both charts without error
- [ ] profile-controller pod starts on `alpine/k8s:1.32.3` and `sync.py` reconciles profiles against the existing MinIO backend
- [ ] training-operator pod starts on v1.9.3 and reconciles a PyTorchJob (example notebook)
- [ ] Pinned digests resolve and pull on the target cluster's architecture (both are multi-arch index digests), and the rendered manifests reference the `tag@sha256:…` form

🤖 Generated with [Claude Code](https://claude.com/claude-code)