### PR TITLE
revert KFP pipelines DB backend to MySQL (Postgres unsupported by cache-server)

### DIFF
--- a/kubeflow/charts/pipelines/Chart.yaml
+++ b/kubeflow/charts/pipelines/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.16.1
 description: A Helm chart for Kubeflow pipelines
 name: kubeflow-pipelines
 type: application
-version: 1.4.0
+version: 1.4.1

--- a/kubeflow/charts/pipelines/ci/ci-values.yaml
+++ b/kubeflow/charts/pipelines/ci/ci-values.yaml
@@ -1,5 +1,0 @@
-# CI-only dummy values so the chart renders (postgres.password is required; terraform
-# supplies the real value at deploy time). Used by the helm-validate workflow.
-postgres:
-  username: postgres
-  password: ci-dummy-postgres-password

--- a/kubeflow/charts/pipelines/templates/authorization_policies.yaml
+++ b/kubeflow/charts/pipelines/templates/authorization_policies.yaml
@@ -168,7 +168,7 @@ kind: AuthorizationPolicy
 metadata:
   labels:
     application-crd-id: kubeflow-pipelines
-  name: postgres
+  name: mysql
   namespace: {{ .Values.kubeflow.namespace }}
 spec:
   rules:
@@ -184,7 +184,7 @@ spec:
         - cluster.local/ns/{{ .Values.kubeflow.namespace }}/sa/metadata-grpc-server
   selector:
     matchLabels:
-      app: postgres
+      app: mysql
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy

--- a/kubeflow/charts/pipelines/templates/config_maps.yaml
+++ b/kubeflow/charts/pipelines/templates/config_maps.yaml
@@ -652,11 +652,11 @@ data:
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
   appVersion: 2.16.1
-  dbHost: postgres # relic to be removed after release
-  dbPort: '5432'   # relic to be removed after release
-  dbType: postgres
-  postgresHost: postgres
-  postgresPort: "5432"
+  dbHost: mysql  # relic to be removed after release
+  dbPort: '3306' # relic to be removed after release
+  dbType: mysql
+  mysqlHost: mysql
+  mysqlPort: "3306"
   mlmdDb: metadb
   cacheDb: cachedb
   pipelineDb: mlpipeline
@@ -681,24 +681,6 @@ metadata:
     application-crd-id: kubeflow-pipelines
   name: pipeline-install-config
   namespace: {{ .Values.kubeflow.namespace }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: postgres
-    application-crd-id: kubeflow-pipelines
-  name: postgres-init
-  namespace: {{ .Values.kubeflow.namespace }}
-data:
-  # Runs once on first init via /docker-entrypoint-initdb.d (the postgres entrypoint only
-  # runs these on an empty PGDATA, so the DBs never pre-exist). The KFP components share
-  # one Postgres instance; create their DBs up front so api-server / MLMD / cache-server
-  # connect to existing databases.
-  init.sql: |
-    CREATE DATABASE mlpipeline;
-    CREATE DATABASE metadb;
-    CREATE DATABASE cachedb;
 ---
 apiVersion: v1
 data:

--- a/kubeflow/charts/pipelines/templates/deployments.yaml
+++ b/kubeflow/charts/pipelines/templates/deployments.yaml
@@ -64,7 +64,7 @@ spec:
               key: cacheNodeRestrictions
               name: pipeline-install-config
         - name: DBCONFIG_DRIVER
-          value: pgx
+          value: mysql
         - name: DBCONFIG_DB_NAME
           valueFrom:
             configMapKeyRef:
@@ -73,23 +73,23 @@ spec:
         - name: DBCONFIG_HOST_NAME
           valueFrom:
             configMapKeyRef:
-              key: postgresHost
+              key: dbHost
               name: pipeline-install-config
         - name: DBCONFIG_PORT
           valueFrom:
             configMapKeyRef:
-              key: postgresPort
+              key: dbPort
               name: pipeline-install-config
         - name: DBCONFIG_USER
           valueFrom:
             secretKeyRef:
               key: username
-              name: postgres-secret
+              name: mysql-secret
         - name: DBCONFIG_PASSWORD
           valueFrom:
             secretKeyRef:
               key: password
-              name: postgres-secret
+              name: mysql-secret
           # If you update WEBHOOK_PORT, also change the value of the
           # containerPort "webhook-api" to match.
         - name: WEBHOOK_PORT
@@ -284,12 +284,11 @@ spec:
       containers:
       - args:
         - --grpc_port=8080
-        - --metadata_source_config_type=postgresql
-        - --postgres_config_dbname=$(POSTGRES_DATABASE)
-        - --postgres_config_host=$(POSTGRES_HOST)
-        - --postgres_config_port=$(POSTGRES_PORT)
-        - --postgres_config_user=$(DBCONFIG_USER)
-        - --postgres_config_password=$(DBCONFIG_PASSWORD)
+        - --mysql_config_database=$(MYSQL_DATABASE)
+        - --mysql_config_host=$(MYSQL_HOST)
+        - --mysql_config_port=$(MYSQL_PORT)
+        - --mysql_config_user=$(DBCONFIG_USER)
+        - --mysql_config_password=$(DBCONFIG_PASSWORD)
         - --enable_database_upgrade=true
         command:
         - /bin/metadata_store_server
@@ -298,26 +297,26 @@ spec:
           valueFrom:
             secretKeyRef:
               key: username
-              name: postgres-secret
+              name: mysql-secret
         - name: DBCONFIG_PASSWORD
           valueFrom:
             secretKeyRef:
               key: password
-              name: postgres-secret
-        - name: POSTGRES_DATABASE
+              name: mysql-secret
+        - name: MYSQL_DATABASE
           valueFrom:
             configMapKeyRef:
               key: mlmdDb
               name: pipeline-install-config
-        - name: POSTGRES_HOST
+        - name: MYSQL_HOST
           valueFrom:
             configMapKeyRef:
-              key: postgresHost
+              key: dbHost
               name: pipeline-install-config
-        - name: POSTGRES_PORT
+        - name: MYSQL_PORT
           valueFrom:
             configMapKeyRef:
-              key: postgresPort
+              key: dbPort
               name: pipeline-install-config
         image: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
         livenessProbe:
@@ -591,6 +590,31 @@ spec:
             configMapKeyRef:
               key: bucketName
               name: pipeline-install-config
+        - name: DBCONFIG_USER
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql-secret
+        - name: DBCONFIG_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql-secret
+        - name: DBCONFIG_DBNAME
+          valueFrom:
+            configMapKeyRef:
+              key: pipelineDb
+              name: pipeline-install-config
+        - name: DBCONFIG_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: dbHost
+              name: pipeline-install-config
+        - name: DBCONFIG_PORT
+          valueFrom:
+            configMapKeyRef:
+              key: dbPort
+              name: pipeline-install-config
         - name: DBCONFIG_CONMAXLIFETIME
           valueFrom:
             configMapKeyRef:
@@ -601,33 +625,33 @@ spec:
             configMapKeyRef:
               name: pipeline-install-config
               key: dbType
-        # Postgres Config
-        - name: DBCONFIG_POSTGRESQLCONFIG_USER
+        # MySQL Config
+        - name: DBCONFIG_MYSQLCONFIG_USER
           valueFrom:
             secretKeyRef:
-              name: postgres-secret
+              name: mysql-secret
               key: username
-        - name: DBCONFIG_POSTGRESQLCONFIG_PASSWORD
+        - name: DBCONFIG_MYSQLCONFIG_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: postgres-secret
+              name: mysql-secret
               key: password
-        - name: DBCONFIG_POSTGRESQLCONFIG_DBNAME
+        - name: DBCONFIG_MYSQLCONFIG_DBNAME
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
               key: pipelineDb
-        - name: DBCONFIG_POSTGRESQLCONFIG_HOST
+        - name: DBCONFIG_MYSQLCONFIG_HOST
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
-              key: postgresHost
-        - name: DBCONFIG_POSTGRESQLCONFIG_PORT
+              key: mysqlHost
+        - name: DBCONFIG_MYSQLCONFIG_PORT
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
-              key: postgresPort
-        # end of Postgres Config
+              key: mysqlPort
+        # end of MySQL Config
         - name: OBJECTSTORECONFIG_ACCESSKEY
           valueFrom:
             secretKeyRef:
@@ -1016,54 +1040,38 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: postgres
+    app: mysql
     application-crd-id: kubeflow-pipelines
-  name: postgres
+  name: mysql
   namespace: {{ .Values.kubeflow.namespace }}
 spec:
   selector:
     matchLabels:
-      app: postgres
+      app: mysql
       application-crd-id: kubeflow-pipelines
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: postgres
+        app: mysql
         application-crd-id: kubeflow-pipelines
     spec:
       containers:
-      - env:
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              key: username
-              name: postgres-secret
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: password
-              name: postgres-secret
-        # Bootstrap DB; the per-component DBs (mlpipeline/metadb/cachedb) are created
-        # by the init script mounted at /docker-entrypoint-initdb.d.
-        - name: POSTGRES_DB
-          value: postgres
-        # Keep PGDATA in a subdir so the volume's lost+found does not block initdb.
-        - name: PGDATA
-          value: /var/lib/postgresql/data/pgdata
-        image: postgres:14.7-alpine3.17
-        name: postgres
+      - args:
+        - --datadir
+        - /var/lib/mysql
+        - --authentication-policy=mysql_native_password
+        - --mysql-native-password=ON
+        - --disable-log-bin
+        env:
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: 'true'
+        image: mysql:8.4
+        name: mysql
         ports:
-        - containerPort: 5432
-          name: postgres
-        readinessProbe:
-          exec:
-            # sh -c so $POSTGRES_USER expands (probe exec does NOT do k8s $(VAR) substitution).
-            command: ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d postgres"]
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 5
+        - containerPort: 3306
+          name: mysql
         resources:
           requests:
             cpu: 100m
@@ -1073,31 +1081,25 @@ spec:
           capabilities:
             drop:
             - ALL
-          runAsGroup: 70
+          runAsGroup: 999
           runAsNonRoot: true
-          runAsUser: 70
+          runAsUser: 999
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
-        - mountPath: /var/lib/postgresql/data
-          name: postgres-persistent-storage
-        - mountPath: /docker-entrypoint-initdb.d
-          name: postgres-init
-          readOnly: true
+        - mountPath: /var/lib/mysql
+          name: mysql-persistent-storage
       securityContext:
-        fsGroup: 70
+        fsGroup: 999
         fsGroupChangePolicy: OnRootMismatch
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: postgres
+      serviceAccountName: mysql
       volumes:
-      - name: postgres-persistent-storage
+      - name: mysql-persistent-storage
         persistentVolumeClaim:
-          claimName: postgres-pvc
-      - name: postgres-init
-        configMap:
-          name: postgres-init
+          claimName: mysql-pv-claim-v2
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubeflow/charts/pipelines/templates/destination_rules.yaml
+++ b/kubeflow/charts/pipelines/templates/destination_rules.yaml
@@ -44,10 +44,10 @@ kind: DestinationRule
 metadata:
   labels:
     application-crd-id: kubeflow-pipelines
-  name: ml-pipeline-postgres
+  name: ml-pipeline-mysql
   namespace: {{ .Values.kubeflow.namespace }}
 spec:
-  host: postgres.{{ .Values.kubeflow.namespace }}.svc.cluster.local
+  host: mysql.{{ .Values.kubeflow.namespace }}.svc.cluster.local
   trafficPolicy:
     tls:
       mode: ISTIO_MUTUAL

--- a/kubeflow/charts/pipelines/templates/pvc.yaml
+++ b/kubeflow/charts/pipelines/templates/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: postgres-pvc
+  name: mysql-pv-claim-v2
   namespace: {{ .Values.kubeflow.namespace }}
   labels:
     application-crd-id: kubeflow-pipelines

--- a/kubeflow/charts/pipelines/templates/secrets.yaml
+++ b/kubeflow/charts/pipelines/templates/secrets.yaml
@@ -16,9 +16,9 @@ metadata:
     app.kubernetes.io/component: ml-pipeline
     app.kubernetes.io/name: kubeflow-pipelines
     application-crd-id: kubeflow-pipelines
-  name: postgres-secret
+  name: mysql-secret
   namespace: {{ .Values.kubeflow.namespace }}
 stringData:
-  username: {{ .Values.postgres.username | quote }}
-  password: {{ required "postgres.password must be set (supplied by terraform)" .Values.postgres.password | quote }}
+  username: root
+  password: ""
 ---

--- a/kubeflow/charts/pipelines/templates/service_accounts.yaml
+++ b/kubeflow/charts/pipelines/templates/service_accounts.yaml
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   labels:
     application-crd-id: kubeflow-pipelines
-  name: postgres
+  name: mysql
   namespace: {{ .Values.kubeflow.namespace }}
 ---
 apiVersion: v1

--- a/kubeflow/charts/pipelines/templates/services.yaml
+++ b/kubeflow/charts/pipelines/templates/services.yaml
@@ -196,15 +196,15 @@ kind: Service
 metadata:
   labels:
     application-crd-id: kubeflow-pipelines
-  name: postgres
+  name: mysql
   namespace: {{ .Values.kubeflow.namespace }}
 spec:
   ports:
-  - port: 5432
+  - port: 3306
     protocol: TCP
-    targetPort: 5432
+    targetPort: 3306
   selector:
-    app: postgres
+    app: mysql
     application-crd-id: kubeflow-pipelines
 ---
 apiVersion: v1

--- a/kubeflow/charts/pipelines/values.yaml
+++ b/kubeflow/charts/pipelines/values.yaml
@@ -6,11 +6,6 @@ ingress:
 minio:
   access_key:
   secret_key:
-# PostgreSQL DB backend credentials. Supplied by terraform (random_password);
-# password is required (the chart fails to render if unset).
-postgres:
-  username: postgres
-  password:
 # Profile namespaces whose default-editor SA (the multi-user pipeline runner) is
 # allowed to call the ml-pipeline backend. Keep in sync with provisioned profiles.
 profile_namespaces:

--- a/kubeflow/terraform/main.tf
+++ b/kubeflow/terraform/main.tf
@@ -81,13 +81,6 @@ resource "random_password" "minio_secret_key" {
   special = false
 }
 
-# PostgreSQL DB backend password for the in-cluster Postgres serving the KFP DBs
-# (mlpipeline/metadb/cachedb). Postgres requires a non-empty password.
-resource "random_password" "postgres_password" {
-  length  = 32
-  special = false
-}
-
 resource "helm_release" "istio_ingress" {
   name             = "istio-ingress"
   chart            = "../charts/istio-ingress"
@@ -251,10 +244,6 @@ resource "helm_release" "kubeflow_pipelines" {
       minio = {
         access_key = random_password.minio_access_key.result
         secret_key = random_password.minio_secret_key.result
-      }
-      postgres = {
-        username = "postgres"
-        password = random_password.postgres_password.result
       }
       # Scopes the ml-pipeline / minio / metadata-grpc AuthorizationPolicies to each
       # profile namespace's default-editor (driven from the same local.profiles list as


### PR DESCRIPTION
## Summary
Reverts the MySQL → PostgreSQL migration (PR #205), restoring the Kubeflow Pipelines DB backend to **MySQL**. The migration broke KFP on the live cluster and is **not viable on this KFP version**.

## Why
KFP's **cache-server has no PostgreSQL support** — not in 2.16.1, and not even on current `master`:
- `backend/src/cache/client_manager.go` imports only `gorm.io/driver/mysql`; the driver `switch` has a single `case "mysql"` (everything else → `Fatalf "Driver %v is not supported"`); `gorm.Open(mysql.Open(arg))` is hardcoded; the string "postgres" appears **0 times** in the whole `backend/src/cache/` tree.
- Live result: `cache-server` CrashLoopBackOff with `Driver pgx is not supported`; the new `ml-pipeline` pod also stalled (its Postgres driver name is `pgx`, not `postgres`). MLMD did work on Postgres, but cache-server is a hard blocker.

(Full analysis recorded on bd platform-oaz.)

## What this does
- Restores the pipelines chart (`templates/*`, `values.yaml`) and `kubeflow/terraform/main.tf` to their **pre-migration MySQL state** (baseline `f044e3e`).
- Removes the Postgres `random_password` + the `ci/ci-values.yaml` fixture.
- **Keeps all non-migration work** — seaweedfs `sync.py`, profile-controller securityContext, cache-server labels (verified: the diff vs the `f044e3e` baseline is *only* the chart version bump).
- Chart `1.4.0 → 1.4.1`.

## Verified
- `helm lint` clean; renders to MySQL (0 Postgres refs, mysql Deployment present); kubeconform gate passes (101 valid, 0 invalid); `terraform fmt` clean.

## Deploy note
After merge + `terragrunt apply`: the `postgres` Deployment/Service/PVC are removed and `mysql` restored; the crashlooping `cache-server` and stuck `ml-pipeline` rollout should recover. `platform-oaz` stays open — Postgres migration is blocked upstream until the cache-server gains Postgres support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)