### PR TITLE
Upgrade Istio 1.27.0 -> 1.30.2 (prereq for EKS 1.34)

### DIFF
--- a/istio/kiali/terraform/main.tf
+++ b/istio/kiali/terraform/main.tf
@@ -14,7 +14,7 @@ module "kiali_operator" {
   namespace        = "kiali-operator"
   create_namespace = true
   chart            = "kiali-operator"
-  chart_version    = "v2.2.0"
+  chart_version    = "v2.26.0"
   repository       = "https://kiali.org/helm-charts"
 
   // CR spec: https://kiali.io/docs/configuration/kialis.kiali.io/

--- a/istio/system/charts/gateway-api-crds/Chart.yaml
+++ b/istio/system/charts/gateway-api-crds/Chart.yaml
@@ -8,8 +8,9 @@ description: >-
   required. Vendored verbatim from kubernetes-sigs/gateway-api v1.5.1
   standard-install.yaml. NOTE: Helm only applies crds/ on first install, never on
   `helm upgrade` — so bumping the version is NOT enough to update the CRDs. To upgrade
-  them, replace crds/standard-install.yaml AND apply it directly
-  (kubectl apply -f / kubectl replace -f), then bump appVersion for tracking.
+  them, replace crds/standard-install.yaml AND apply it directly with server-side apply
+  (kubectl apply --server-side -f crds/standard-install.yaml), then bump appVersion for
+  tracking.
 type: application
 version: 1.0.0
 appVersion: "1.5.1"

--- a/istio/system/charts/gateway-api-crds/Chart.yaml
+++ b/istio/system/charts/gateway-api-crds/Chart.yaml
@@ -2,12 +2,14 @@ apiVersion: v2
 name: gateway-api-crds
 description: >-
   Kubernetes Gateway API standard-channel CRDs (GatewayClass, Gateway, HTTPRoute,
-  GRPCRoute, ReferenceGrant). Required by Istio ambient waypoints; istiod creates the
-  istio-waypoint GatewayClass once these exist. Vendored verbatim from
-  kubernetes-sigs/gateway-api v1.2.1 standard-install.yaml. NOTE: Helm only applies
-  crds/ on first install, never on `helm upgrade` — so bumping the version is NOT enough
-  to update the CRDs. To upgrade them, replace crds/standard-install.yaml AND apply it
-  directly (kubectl apply -f / kubectl replace -f), then bump appVersion for tracking.
+  GRPCRoute, ReferenceGrant, TLSRoute, ListenerSet, BackendTLSPolicy). Required by Istio
+  ambient waypoints; istiod creates the istio-waypoint GatewayClass once these exist.
+  Istio 1.30 reads TLSRoute/ReferenceGrant from the standard channel, so v1.5.x is
+  required. Vendored verbatim from kubernetes-sigs/gateway-api v1.5.1
+  standard-install.yaml. NOTE: Helm only applies crds/ on first install, never on
+  `helm upgrade` — so bumping the version is NOT enough to update the CRDs. To upgrade
+  them, replace crds/standard-install.yaml AND apply it directly
+  (kubectl apply -f / kubectl replace -f), then bump appVersion for tracking.
 type: application
 version: 1.0.0
-appVersion: "1.2.1"
+appVersion: "1.5.1"

--- a/istio/system/charts/gateway-api-crds/Chart.yaml
+++ b/istio/system/charts/gateway-api-crds/Chart.yaml
@@ -5,12 +5,12 @@ description: >-
   GRPCRoute, ReferenceGrant, TLSRoute, ListenerSet, BackendTLSPolicy). Required by Istio
   ambient waypoints; istiod creates the istio-waypoint GatewayClass once these exist.
   Istio 1.30 reads TLSRoute/ReferenceGrant from the standard channel, so v1.5.x is
-  required. Vendored verbatim from kubernetes-sigs/gateway-api v1.5.1
-  standard-install.yaml. NOTE: Helm only applies crds/ on first install, never on
-  `helm upgrade` — so bumping the version is NOT enough to update the CRDs. To upgrade
-  them, replace crds/standard-install.yaml AND apply it directly with server-side apply
-  (kubectl apply --server-side -f crds/standard-install.yaml), then bump appVersion for
-  tracking.
+  required. Vendored from kubernetes-sigs/gateway-api v1.5.1 standard-install.yaml under
+  templates/ (NOT crds/) so `helm upgrade` reconciles them on every apply — same pattern
+  as prometheus-operator-crds. Each object carries `helm.sh/resource-policy: keep` so the
+  CRDs (and their custom resources) survive `helm uninstall`. To bump: replace
+  templates/standard-install.yaml with the new release bundle, re-add the keep annotation,
+  and update appVersion.
 type: application
 version: 1.0.0
 appVersion: "1.5.1"

--- a/istio/system/charts/gateway-api-crds/crds/standard-install.yaml
+++ b/istio/system/charts/gateway-api-crds/crds/standard-install.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,16 +17,1401 @@
 #
 ---
 #
+# config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendtlspolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendTLSPolicy
+    listKind: BackendTLSPolicyList
+    plural: backendtlspolicies
+    shortNames:
+    - btlspolicy
+    singular: backendtlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackendTLSPolicy provides a way to configure how a Gateway
+          connects to a Backend via TLS.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              options:
+                additionalProperties:
+                  description: |-
+                    AnnotationValue is the value of an annotation in Gateway API. This is used
+                    for validation of maps such as TLS options. This roughly matches Kubernetes
+                    annotation validation, although the length validation in that case is based
+                    on the entire size of the annotations struct.
+                  maxLength: 4096
+                  minLength: 0
+                  type: string
+                description: |-
+                  Options are a list of key/value pairs to enable extended TLS
+                  configuration for each implementation. For example, configuring the
+                  minimum TLS version or supported cipher suites.
+
+                  A set of common keys MAY be defined by the API in the future. To avoid
+                  any ambiguity, implementation-specific definitions MUST use
+                  domain-prefixed names, such as `example.com/my-custom-option`.
+                  Un-prefixed names are reserved for key names defined by Gateway API.
+
+                  Support: Implementation-specific
+                maxProperties: 16
+                type: object
+              targetRefs:
+                description: |-
+                  TargetRefs identifies an API object to apply the policy to.
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
+
+                  TargetRefs must be _distinct_. This means either that:
+
+                  * They select different targets. If this is the case, then targetRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, and `name` must
+                    be unique across all targetRef entries in the BackendTLSPolicy.
+                  * They select different sectionNames in the same target.
+
+                  When more than one BackendTLSPolicy selects the same target and
+                  sectionName, implementations MUST determine precedence using the
+                  following criteria, continuing on ties:
+
+                  * The older policy by creation timestamp takes precedence. For
+                    example, a policy with a creation timestamp of "2021-07-15
+                    01:02:03" MUST be given precedence over a policy with a
+                    creation timestamp of "2021-07-15 01:02:04".
+                  * The policy appearing first in alphabetical order by {namespace}/{name}.
+                    For example, a policy named `foo/bar` is given precedence over a
+                    policy named `foo/baz`.
+
+                  For any BackendTLSPolicy that does not take precedence, the
+                  implementation MUST ensure the `Accepted` Condition is set to
+                  `status: False`, with Reason `Conflicted`.
+
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
+                  Support Levels:
+
+                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
+
+                  * Implementation-Specific: Services not connected via HTTPRoute, and any
+                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
+                    - Services not referenced by any Route (e.g., infrastructure services)
+                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
+                    - Service mesh workload-to-service communication
+                    - Other resource types beyond Service
+
+                  Implementations SHOULD aim to ensure that BackendTLSPolicy behavior is consistent,
+                  even outside of the extended HTTPRoute -(backendRef) -> Service path.
+                  They SHOULD clearly document how BackendTLSPolicy is interpreted in these
+                  scenarios, including:
+                    - Which resources beyond Service are supported
+                    - How the policy is discovered and applied
+                    - Any implementation-specific semantics or restrictions
+
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
+                items:
+                  description: |-
+                    LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                    direct policy to. This should be used as part of Policy resources that can
+                    target single resources. For more information on how this policy attachment
+                    mode works, and a sample Policy resource, refer to the policy attachment
+                    documentation for Gateway API.
+
+                    Note: This should only be used for direct policy attachment when references
+                    to SectionName are actually needed. In all other cases,
+                    LocalPolicyTargetReference should be used.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. When
+                        unspecified, this targetRef targets the entire resource. In the following
+                        resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name
+                        * HTTPRoute: HTTPRouteRule name
+                        * Service: Port name
+
+                        If a SectionName is specified, but does not exist on the targeted object,
+                        the Policy must fail to attach, and the policy implementation should record
+                        a `ResolvedRefs` or similar Condition in the Policy's status.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when targetRefs includes
+                    2 or more references to the same target
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name ? ((!has(p1.sectionName) || p1.sectionName
+                    == '''') == (!has(p2.sectionName) || p2.sectionName == ''''))
+                    : true))'
+                - message: sectionName must be unique when targetRefs includes 2 or
+                    more references to the same target
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.sectionName) ||
+                    p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              validation:
+                description: Validation contains backend TLS validation configuration.
+                properties:
+                  caCertificateRefs:
+                    description: |-
+                      CACertificateRefs contains one or more references to Kubernetes objects that
+                      contain a PEM-encoded TLS CA certificate bundle, which is used to
+                      validate a TLS handshake between the Gateway and backend Pod.
+
+                      If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                      specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                      not both. If CACertificateRefs is empty or unspecified, the configuration for
+                      WellKnownCACertificates MUST be honored instead if supported by the implementation.
+
+                      A CACertificateRef is invalid if:
+
+                      * It refers to a resource that cannot be resolved (e.g., the referenced resource
+                        does not exist) or is misconfigured (e.g., a ConfigMap does not contain a key
+                        named `ca.crt`). In this case, the Reason must be set to `InvalidCACertificateRef`
+                        and the Message of the Condition must indicate which reference is invalid and why.
+
+                      * It refers to an unknown or unsupported kind of resource. In this case, the Reason
+                        must be set to `InvalidKind` and the Message of the Condition must explain which
+                        kind of resource is unknown or unsupported.
+
+                      * It refers to a resource in another namespace. This may change in future
+                        spec updates.
+
+                      Implementations MAY choose to perform further validation of the certificate
+                      content (e.g., checking expiry or enforcing specific formats). In such cases,
+                      an implementation-specific Reason and Message must be set for the invalid reference.
+
+                      In all cases, the implementation MUST ensure the `ResolvedRefs` Condition on
+                      the BackendTLSPolicy is set to `status: False`, with a Reason and Message
+                      that indicate the cause of the error. Connections using an invalid
+                      CACertificateRef MUST fail, and the client MUST receive an HTTP 5xx error
+                      response. If ALL CACertificateRefs are invalid, the implementation MUST also
+                      ensure the `Accepted` Condition on the BackendTLSPolicy is set to
+                      `status: False`, with a Reason `NoValidCACertificate`.
+
+                      A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
+                      Implementations MAY choose to support attaching multiple certificates to
+                      a backend, but this behavior is implementation-specific.
+
+                      Support: Core - An optional single reference to a Kubernetes ConfigMap,
+                      with the CA certificate in a key named `ca.crt`.
+
+                      Support: Implementation-specific - More than one reference, other kinds
+                      of resources, or a single reference that includes multiple certificates.
+                    items:
+                      description: |-
+                        LocalObjectReference identifies an API object within the namespace of the
+                        referrer.
+                        The API object must be valid in the cluster; the Group and Kind must
+                        be registered in the cluster for this reference to be valid.
+
+                        References to objects with invalid Group and Kind are not valid, and must
+                        be rejected by the implementation, with appropriate Conditions set
+                        on the containing object.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  hostname:
+                    description: |-
+                      Hostname is used for two purposes in the connection between Gateways and
+                      backends:
+
+                      1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
+                      2. Hostname MUST be used for authentication and MUST match the certificate
+                         served by the matching backend, unless SubjectAltNames is specified.
+                      3. If SubjectAltNames are specified, Hostname can be used for certificate selection
+                         but MUST NOT be used for authentication. If you want to use the value
+                         of the Hostname field for authentication, you MUST add it to the SubjectAltNames list.
+
+                      Support: Core
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  subjectAltNames:
+                    description: |-
+                      SubjectAltNames contains one or more Subject Alternative Names.
+                      When specified the certificate served from the backend MUST
+                      have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
+
+                      Support: Extended
+                    items:
+                      description: SubjectAltName represents Subject Alternative Name.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname contains Subject Alternative Name specified in DNS name format.
+                            Required when Type is set to Hostname, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type:
+                          description: |-
+                            Type determines the format of the Subject Alternative Name. Always required.
+
+                            Support: Core
+                          enum:
+                          - Hostname
+                          - URI
+                          type: string
+                        uri:
+                          description: |-
+                            URI contains Subject Alternative Name specified in a full URI format.
+                            It MUST include both a scheme (e.g., "http" or "ftp") and a scheme-specific-part.
+                            Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+                            Required when Type is set to URI, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: SubjectAltName element must contain Hostname, if
+                          Type is set to Hostname
+                        rule: '!(self.type == "Hostname" && (!has(self.hostname) ||
+                          self.hostname == ""))'
+                      - message: SubjectAltName element must not contain Hostname,
+                          if Type is not set to Hostname
+                        rule: '!(self.type != "Hostname" && has(self.hostname) &&
+                          self.hostname != "")'
+                      - message: SubjectAltName element must contain URI, if Type
+                          is set to URI
+                        rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                          == ""))'
+                      - message: SubjectAltName element must not contain URI, if Type
+                          is not set to URI
+                        rule: '!(self.type != "URI" && has(self.uri) && self.uri !=
+                          "")'
+                    maxItems: 5
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  wellKnownCACertificates:
+                    description: |-
+                      WellKnownCACertificates specifies whether a well-known set of CA certificates
+                      may be used in the TLS handshake between the gateway and backend pod.
+
+                      If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                      must be specified with at least one entry for a valid configuration. Only one of
+                      CACertificateRefs or WellKnownCACertificates may be specified, not both.
+                      If an implementation does not support the WellKnownCACertificates field, or
+                      the supplied value is not recognized, the implementation MUST ensure the
+                      `Accepted` Condition on the BackendTLSPolicy is set to `status: False`, with
+                      a Reason `Invalid`.
+
+                      Valid values include:
+                      * "System" - indicates that well-known system CA certificates should be used.
+
+                      Implementations MAY define their own sets of CA certificates. Such definitions
+                      MUST use an implementation-specific, prefixed name, such as
+                      `mycompany.com/my-custom-ca-certificates`.
+
+                      Support: Implementation-specific
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(System|([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]))$
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                  rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                - message: must specify either CACertificateRefs or WellKnownCACertificates
+                  rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")
+            required:
+            - targetRefs
+            - validation
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - conditions
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: The v1alpha3 version of BackendTLSPolicy has been deprecated
+      and will be removed in a future release of the API. Please upgrade to v1.
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackendTLSPolicy provides a way to configure how a Gateway
+          connects to a Backend via TLS.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              options:
+                additionalProperties:
+                  description: |-
+                    AnnotationValue is the value of an annotation in Gateway API. This is used
+                    for validation of maps such as TLS options. This roughly matches Kubernetes
+                    annotation validation, although the length validation in that case is based
+                    on the entire size of the annotations struct.
+                  maxLength: 4096
+                  minLength: 0
+                  type: string
+                description: |-
+                  Options are a list of key/value pairs to enable extended TLS
+                  configuration for each implementation. For example, configuring the
+                  minimum TLS version or supported cipher suites.
+
+                  A set of common keys MAY be defined by the API in the future. To avoid
+                  any ambiguity, implementation-specific definitions MUST use
+                  domain-prefixed names, such as `example.com/my-custom-option`.
+                  Un-prefixed names are reserved for key names defined by Gateway API.
+
+                  Support: Implementation-specific
+                maxProperties: 16
+                type: object
+              targetRefs:
+                description: |-
+                  TargetRefs identifies an API object to apply the policy to.
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
+
+                  TargetRefs must be _distinct_. This means either that:
+
+                  * They select different targets. If this is the case, then targetRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, and `name` must
+                    be unique across all targetRef entries in the BackendTLSPolicy.
+                  * They select different sectionNames in the same target.
+
+                  When more than one BackendTLSPolicy selects the same target and
+                  sectionName, implementations MUST determine precedence using the
+                  following criteria, continuing on ties:
+
+                  * The older policy by creation timestamp takes precedence. For
+                    example, a policy with a creation timestamp of "2021-07-15
+                    01:02:03" MUST be given precedence over a policy with a
+                    creation timestamp of "2021-07-15 01:02:04".
+                  * The policy appearing first in alphabetical order by {namespace}/{name}.
+                    For example, a policy named `foo/bar` is given precedence over a
+                    policy named `foo/baz`.
+
+                  For any BackendTLSPolicy that does not take precedence, the
+                  implementation MUST ensure the `Accepted` Condition is set to
+                  `status: False`, with Reason `Conflicted`.
+
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
+                  Support Levels:
+
+                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
+
+                  * Implementation-Specific: Services not connected via HTTPRoute, and any
+                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
+                    - Services not referenced by any Route (e.g., infrastructure services)
+                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
+                    - Service mesh workload-to-service communication
+                    - Other resource types beyond Service
+
+                  Implementations SHOULD aim to ensure that BackendTLSPolicy behavior is consistent,
+                  even outside of the extended HTTPRoute -(backendRef) -> Service path.
+                  They SHOULD clearly document how BackendTLSPolicy is interpreted in these
+                  scenarios, including:
+                    - Which resources beyond Service are supported
+                    - How the policy is discovered and applied
+                    - Any implementation-specific semantics or restrictions
+
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
+                items:
+                  description: |-
+                    LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                    direct policy to. This should be used as part of Policy resources that can
+                    target single resources. For more information on how this policy attachment
+                    mode works, and a sample Policy resource, refer to the policy attachment
+                    documentation for Gateway API.
+
+                    Note: This should only be used for direct policy attachment when references
+                    to SectionName are actually needed. In all other cases,
+                    LocalPolicyTargetReference should be used.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. When
+                        unspecified, this targetRef targets the entire resource. In the following
+                        resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name
+                        * HTTPRoute: HTTPRouteRule name
+                        * Service: Port name
+
+                        If a SectionName is specified, but does not exist on the targeted object,
+                        the Policy must fail to attach, and the policy implementation should record
+                        a `ResolvedRefs` or similar Condition in the Policy's status.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when targetRefs includes
+                    2 or more references to the same target
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name ? ((!has(p1.sectionName) || p1.sectionName
+                    == '''') == (!has(p2.sectionName) || p2.sectionName == ''''))
+                    : true))'
+                - message: sectionName must be unique when targetRefs includes 2 or
+                    more references to the same target
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.sectionName) ||
+                    p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              validation:
+                description: Validation contains backend TLS validation configuration.
+                properties:
+                  caCertificateRefs:
+                    description: |-
+                      CACertificateRefs contains one or more references to Kubernetes objects that
+                      contain a PEM-encoded TLS CA certificate bundle, which is used to
+                      validate a TLS handshake between the Gateway and backend Pod.
+
+                      If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                      specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                      not both. If CACertificateRefs is empty or unspecified, the configuration for
+                      WellKnownCACertificates MUST be honored instead if supported by the implementation.
+
+                      A CACertificateRef is invalid if:
+
+                      * It refers to a resource that cannot be resolved (e.g., the referenced resource
+                        does not exist) or is misconfigured (e.g., a ConfigMap does not contain a key
+                        named `ca.crt`). In this case, the Reason must be set to `InvalidCACertificateRef`
+                        and the Message of the Condition must indicate which reference is invalid and why.
+
+                      * It refers to an unknown or unsupported kind of resource. In this case, the Reason
+                        must be set to `InvalidKind` and the Message of the Condition must explain which
+                        kind of resource is unknown or unsupported.
+
+                      * It refers to a resource in another namespace. This may change in future
+                        spec updates.
+
+                      Implementations MAY choose to perform further validation of the certificate
+                      content (e.g., checking expiry or enforcing specific formats). In such cases,
+                      an implementation-specific Reason and Message must be set for the invalid reference.
+
+                      In all cases, the implementation MUST ensure the `ResolvedRefs` Condition on
+                      the BackendTLSPolicy is set to `status: False`, with a Reason and Message
+                      that indicate the cause of the error. Connections using an invalid
+                      CACertificateRef MUST fail, and the client MUST receive an HTTP 5xx error
+                      response. If ALL CACertificateRefs are invalid, the implementation MUST also
+                      ensure the `Accepted` Condition on the BackendTLSPolicy is set to
+                      `status: False`, with a Reason `NoValidCACertificate`.
+
+                      A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
+                      Implementations MAY choose to support attaching multiple certificates to
+                      a backend, but this behavior is implementation-specific.
+
+                      Support: Core - An optional single reference to a Kubernetes ConfigMap,
+                      with the CA certificate in a key named `ca.crt`.
+
+                      Support: Implementation-specific - More than one reference, other kinds
+                      of resources, or a single reference that includes multiple certificates.
+                    items:
+                      description: |-
+                        LocalObjectReference identifies an API object within the namespace of the
+                        referrer.
+                        The API object must be valid in the cluster; the Group and Kind must
+                        be registered in the cluster for this reference to be valid.
+
+                        References to objects with invalid Group and Kind are not valid, and must
+                        be rejected by the implementation, with appropriate Conditions set
+                        on the containing object.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  hostname:
+                    description: |-
+                      Hostname is used for two purposes in the connection between Gateways and
+                      backends:
+
+                      1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
+                      2. Hostname MUST be used for authentication and MUST match the certificate
+                         served by the matching backend, unless SubjectAltNames is specified.
+                      3. If SubjectAltNames are specified, Hostname can be used for certificate selection
+                         but MUST NOT be used for authentication. If you want to use the value
+                         of the Hostname field for authentication, you MUST add it to the SubjectAltNames list.
+
+                      Support: Core
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  subjectAltNames:
+                    description: |-
+                      SubjectAltNames contains one or more Subject Alternative Names.
+                      When specified the certificate served from the backend MUST
+                      have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
+
+                      Support: Extended
+                    items:
+                      description: SubjectAltName represents Subject Alternative Name.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname contains Subject Alternative Name specified in DNS name format.
+                            Required when Type is set to Hostname, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type:
+                          description: |-
+                            Type determines the format of the Subject Alternative Name. Always required.
+
+                            Support: Core
+                          enum:
+                          - Hostname
+                          - URI
+                          type: string
+                        uri:
+                          description: |-
+                            URI contains Subject Alternative Name specified in a full URI format.
+                            It MUST include both a scheme (e.g., "http" or "ftp") and a scheme-specific-part.
+                            Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+                            Required when Type is set to URI, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: SubjectAltName element must contain Hostname, if
+                          Type is set to Hostname
+                        rule: '!(self.type == "Hostname" && (!has(self.hostname) ||
+                          self.hostname == ""))'
+                      - message: SubjectAltName element must not contain Hostname,
+                          if Type is not set to Hostname
+                        rule: '!(self.type != "Hostname" && has(self.hostname) &&
+                          self.hostname != "")'
+                      - message: SubjectAltName element must contain URI, if Type
+                          is set to URI
+                        rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                          == ""))'
+                      - message: SubjectAltName element must not contain URI, if Type
+                          is not set to URI
+                        rule: '!(self.type != "URI" && has(self.uri) && self.uri !=
+                          "")'
+                    maxItems: 5
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  wellKnownCACertificates:
+                    description: |-
+                      WellKnownCACertificates specifies whether a well-known set of CA certificates
+                      may be used in the TLS handshake between the gateway and backend pod.
+
+                      If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                      must be specified with at least one entry for a valid configuration. Only one of
+                      CACertificateRefs or WellKnownCACertificates may be specified, not both.
+                      If an implementation does not support the WellKnownCACertificates field, or
+                      the supplied value is not recognized, the implementation MUST ensure the
+                      `Accepted` Condition on the BackendTLSPolicy is set to `status: False`, with
+                      a Reason `Invalid`.
+
+                      Valid values include:
+                      * "System" - indicates that well-known system CA certificates should be used.
+
+                      Implementations MAY define their own sets of CA certificates. Such definitions
+                      MUST use an implementation-specific, prefixed name, such as
+                      `mycompany.com/my-custom-ca-certificates`.
+
+                      Support: Implementation-specific
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(System|([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]))$
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                  rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                - message: must specify either CACertificateRefs or WellKnownCACertificates
+                  rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")
+            required:
+            - targetRefs
+            - validation
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - conditions
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
 # config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
-  creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -258,6 +1643,25 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              supportedFeatures:
+                description: |-
+                  SupportedFeatures is the set of features the GatewayClass support.
+                  It MUST be sorted in ascending alphabetical order by the Name key.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        FeatureName is used to describe distinct features that are covered by
+                        conformance tests.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         required:
         - spec
@@ -483,6 +1887,25 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              supportedFeatures:
+                description: |-
+                  SupportedFeatures is the set of features the GatewayClass support.
+                  It MUST be sorted in ascending alphabetical order by the Name key.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        FeatureName is used to describe distinct features that are covered by
+                        conformance tests.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         required:
         - spec
@@ -505,10 +1928,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
-  creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -564,11 +1986,11 @@ spec:
             description: Spec defines the desired state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
-                  indicate this in the associated entry in GatewayStatus.Addresses.
+                  indicate this in an associated entry in GatewayStatus.Conditions.
 
                   The Addresses field represents a request for the address(es) on the
                   "outside of the Gateway", that traffic bound for this Gateway will use.
@@ -585,10 +2007,9 @@ spec:
                   GatewayStatus.Addresses.
 
                   Support: Extended
-
                 items:
-                  description: GatewayAddress describes an address that can be bound
-                    to a Gateway.
+                  description: GatewaySpecAddress describes an address that can be
+                    bound to a Gateway.
                   oneOf:
                   - properties:
                       type:
@@ -613,30 +2034,114 @@ spec:
                       type: string
                     value:
                       description: |-
-                        Value of the address. The validity of the values will depend
-                        on the type and support by the controller.
+                        When a value is unspecified, an implementation SHOULD automatically
+                        assign an address matching the requested type if possible.
+
+                        If an implementation does not support an empty value, they MUST set the
+                        "Programmed" condition in status to False with a reason of "AddressNotAssigned".
 
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
-                      minLength: 1
                       type: string
-                  required:
-                  - value
                   type: object
                   x-kubernetes-validations:
-                  - message: Hostname value must only contain valid characters (matching
-                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
-                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                  - message: Hostname value must be empty or contain only valid characters
+                      (matching ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? (!has(self.value) || self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$""")):
                       true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: IPAddress values must be unique
-                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
-                    a2.type == a1.type && a2.value == a1.value) : true )'
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
                 - message: Hostname values must be unique
-                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
-                    a2.type == a1.type && a2.value == a1.value) : true )'
+                  rule: 'self.all(a1, a1.type == ''Hostname''  && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
+              allowedListeners:
+                description: |-
+                  AllowedListeners defines which ListenerSets can be attached to this Gateway.
+                  The default value is to allow no ListenerSets.
+                properties:
+                  namespaces:
+                    default:
+                      from: None
+                    description: |-
+                      Namespaces defines which namespaces ListenerSets can be attached to this Gateway.
+                      The default value is to allow no ListenerSets.
+                    properties:
+                      from:
+                        default: None
+                        description: |-
+                          From indicates where ListenerSets can attach to this Gateway. Possible
+                          values are:
+
+                          * Same: Only ListenerSets in the same namespace may be attached to this Gateway.
+                          * Selector: ListenerSets in namespaces selected by the selector may be attached to this Gateway.
+                          * All: ListenerSets in all namespaces may be attached to this Gateway.
+                          * None: Only listeners defined in the Gateway's spec are allowed
+
+                          The default value None
+                        enum:
+                        - All
+                        - Selector
+                        - Same
+                        - None
+                        type: string
+                      selector:
+                        description: |-
+                          Selector must be specified when From is set to "Selector". In that case,
+                          only ListenerSets in Namespaces matching this Selector will be selected by this
+                          Gateway. This field is ignored for other values of "From".
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                type: object
               gatewayClassName:
                 description: |-
                   GatewayClassName used for this Gateway. This is the name of a
@@ -731,6 +2236,11 @@ spec:
                       the merging behavior is implementation specific.
                       It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
 
+                      If the referent cannot be found, refers to an unsupported kind, or when
+                      the data within that resource is malformed, the Gateway SHOULD be
+                      rejected with the "Accepted" status condition set to "False" and an
+                      "InvalidParameters" reason.
+
                       Support: Implementation-specific
                     properties:
                       group:
@@ -761,6 +2271,8 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses.
                   At least one Listener MUST be specified.
 
+                  ## Distinct Listeners
+
                   Each Listener in a set of Listeners (for example, in a single Gateway)
                   MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
                   exactly one listener. (This section uses "set of Listeners" rather than
@@ -772,55 +2284,76 @@ spec:
                   combination of Port, Protocol, and, if supported by the protocol, Hostname.
 
                   Some combinations of port, protocol, and TLS settings are considered
-                  Core support and MUST be supported by implementations based on their
-                  targeted conformance profile:
+                  Core support and MUST be supported by implementations based on the objects
+                  they support:
 
-                  HTTP Profile
+                  HTTPRoute
 
                   1. HTTPRoute, Port: 80, Protocol: HTTP
                   2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
 
-                  TLS Profile
+                  TLSRoute
 
                   1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
 
                   "Distinct" Listeners have the following property:
 
-                  The implementation can match inbound requests to a single distinct
-                  Listener. When multiple Listeners share values for fields (for
+                  **The implementation can match inbound requests to a single distinct
+                  Listener**.
+
+                  When multiple Listeners share values for fields (for
                   example, two Listeners with the same Port value), the implementation
                   can match requests to only one of the Listeners using other
                   Listener fields.
 
-                  For example, the following Listener scenarios are distinct:
+                  When multiple listeners have the same value for the Protocol field, then
+                  each of the Listeners with matching Protocol values MUST have different
+                  values for other fields.
 
-                  1. Multiple Listeners with the same Port that all use the "HTTP"
-                     Protocol that all have unique Hostname values.
-                  2. Multiple Listeners with the same Port that use either the "HTTPS" or
-                     "TLS" Protocol that all have unique Hostname values.
-                  3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
-                     with the same Protocol has the same Port value.
+                  The set of fields that MUST be different for a Listener differs per protocol.
+                  The following rules define the rules for what fields MUST be considered for
+                  Listeners to be distinct with each protocol currently defined in the
+                  Gateway API spec.
 
-                  Some fields in the Listener struct have possible values that affect
-                  whether the Listener is distinct. Hostname is particularly relevant
-                  for HTTP or HTTPS protocols.
+                  The set of listeners that all share a protocol value MUST have _different_
+                  values for _at least one_ of these fields to be distinct:
 
-                  When using the Hostname value to select between same-Port, same-Protocol
-                  Listeners, the Hostname value must be different on each Listener for the
-                  Listener to be distinct.
+                  * **HTTP, HTTPS, TLS**: Port, Hostname
+                  * **TCP, UDP**: Port
 
-                  When the Listeners are distinct based on Hostname, inbound request
+                  One **very** important rule to call out involves what happens when an
+                  implementation:
+
+                  * Supports TCP protocol Listeners, as well as HTTP, HTTPS, or TLS protocol
+                    Listeners, and
+                  * sees HTTP, HTTPS, or TLS protocols with the same `port` as one with TCP
+                    Protocol.
+
+                  In this case all the Listeners that share a port with the
+                  TCP Listener are not distinct and so MUST NOT be accepted.
+
+                  If an implementation does not support TCP Protocol Listeners, then the
+                  previous rule does not apply, and the TCP Listeners SHOULD NOT be
+                  accepted.
+
+                  Note that the `tls` field is not used for determining if a listener is distinct, because
+                  Listeners that _only_ differ on TLS config will still conflict in all cases.
+
+                  ### Listeners that are distinct only by Hostname
+
+                  When the Listeners are distinct based only on Hostname, inbound request
                   hostnames MUST match from the most specific to least specific Hostname
                   values to choose the correct Listener and its associated set of Routes.
 
-                  Exact matches must be processed before wildcard matches, and wildcard
-                  matches must be processed before fallback (empty Hostname value)
+                  Exact matches MUST be processed before wildcard matches, and wildcard
+                  matches MUST be processed before fallback (empty Hostname value)
                   matches. For example, `"foo.example.com"` takes precedence over
                   `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
 
                   Additionally, if there are multiple wildcard entries, more specific
                   wildcard entries must be processed before less specific wildcard entries.
                   For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+
                   The precise definition here is that the higher the number of dots in the
                   hostname to the right of the wildcard character, the higher the precedence.
 
@@ -828,18 +2361,26 @@ spec:
                   the left, however, so `"*.example.com"` will match both
                   `"foo.bar.example.com"` _and_ `"bar.example.com"`.
 
+                  ## Handling indistinct Listeners
+
                   If a set of Listeners contains Listeners that are not distinct, then those
-                  Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                  Listeners are _Conflicted_, and the implementation MUST set the "Conflicted"
                   condition in the Listener Status to "True".
+
+                  The words "indistinct" and "conflicted" are considered equivalent for the
+                  purpose of this documentation.
 
                   Implementations MAY choose to accept a Gateway with some Conflicted
                   Listeners only if they only accept the partial Listener set that contains
-                  no Conflicted Listeners. To put this another way, implementations may
-                  accept a partial Listener set only if they throw out *all* the conflicting
-                  Listeners. No picking one of the conflicting listeners as the winner.
-                  This also means that the Gateway must have at least one non-conflicting
-                  Listener in this case, otherwise it violates the requirement that at
-                  least one Listener must be present.
+                  no Conflicted Listeners.
+
+                  Specifically, an implementation MAY accept a partial Listener set subject to
+                  the following rules:
+
+                  * The implementation MUST NOT pick one conflicting Listener as the winner.
+                    ALL indistinct Listeners must not be accepted for processing.
+                  * At least one distinct Listener MUST be present, or else the Gateway effectively
+                    contains _no_ Listeners, and must be rejected from processing as a whole.
 
                   The implementation MUST set a "ListenersNotValid" condition on the
                   Gateway Status when the Gateway contains Conflicted Listeners whether or
@@ -848,7 +2389,25 @@ spec:
                   Accepted. Additionally, the Listener status for those listeners SHOULD
                   indicate which Listeners are conflicted and not Accepted.
 
-                  A Gateway's Listeners are considered "compatible" if:
+                  ## General Listener behavior
+
+                  Note that, for all distinct Listeners, requests SHOULD match at most one Listener.
+                  For example, if Listeners are defined for "foo.example.com" and "*.example.com", a
+                  request to "foo.example.com" SHOULD only be routed using routes attached
+                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+
+                  This concept is known as "Listener Isolation", and it is an Extended feature
+                  of Gateway API. Implementations that do not support Listener Isolation MUST
+                  clearly document this, and MUST NOT claim support for the
+                  `GatewayHTTPListenerIsolation` feature.
+
+                  Implementations that _do_ support Listener Isolation SHOULD claim support
+                  for the Extended `GatewayHTTPListenerIsolation` feature and pass the associated
+                  conformance tests.
+
+                  ## Compatible Listeners
+
+                  A Gateway's Listeners are considered _compatible_ if:
 
                   1. They are distinct.
                   2. The implementation can serve them in compliance with the Addresses
@@ -863,15 +2422,10 @@ spec:
                   on the same address, or cannot mix HTTPS and generic TLS listens on the same port
                   would not consider those cases compatible, even though they are distinct.
 
-                  Note that requests SHOULD match at most one Listener. For example, if
-                  Listeners are defined for "foo.example.com" and "*.example.com", a
-                  request to "foo.example.com" SHOULD only be routed using routes attached
-                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
-                  This concept is known as "Listener Isolation". Implementations that do
-                  not support Listener Isolation MUST clearly document this.
-
                   Implementations MAY merge separate Gateways onto a single set of
                   Addresses if all Listeners across all Gateways are compatible.
+
+                  In a future release the MinItems=1 requirement MAY be dropped.
 
                   Support: Core
                 items:
@@ -943,6 +2497,7 @@ spec:
                             type: object
                           maxItems: 8
                           type: array
+                          x-kubernetes-list-type: atomic
                         namespaces:
                           default:
                             from: Same
@@ -1034,10 +2589,31 @@ spec:
 
                         * TLS: The Listener Hostname MUST match the SNI.
                         * HTTP: The Listener Hostname MUST match the Host header of the request.
-                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
-                          protocol layers as described above. If an implementation does not
-                          ensure that both the SNI and Host header match the Listener hostname,
-                          it MUST clearly document that.
+                        * HTTPS: The Listener Hostname SHOULD match both the SNI and Host header.
+                          Note that this does not require the SNI and Host header to be the same.
+                          The semantics of this are described in more detail below.
+
+                        To ensure security, Section 11.1 of RFC-6066 emphasizes that server
+                        implementations that rely on SNI hostname matching MUST also verify
+                        hostnames within the application protocol.
+
+                        Section 9.1.2 of RFC-7540 provides a mechanism for servers to reject the
+                        reuse of a connection by responding with the HTTP 421 Misdirected Request
+                        status code. This indicates that the origin server has rejected the
+                        request because it appears to have been misdirected.
+
+                        To detect misdirected requests, Gateways SHOULD match the authority of
+                        the requests with all the SNI hostname(s) configured across all the
+                        Gateway Listeners on the same port and protocol:
+
+                        * If another Listener has an exact match or more specific wildcard entry,
+                          the Gateway SHOULD return a 421.
+                        * If the current Listener (selected by SNI matching during ClientHello)
+                          does not match the Host:
+                            * If another Listener does match the Host, the Gateway SHOULD return a
+                              421.
+                            * If no other Listener matches the Host, the Gateway MUST return a
+                              404.
 
                         For HTTPRoute and TLSRoute resources, there is an interaction with the
                         `spec.hostnames` array. When both listener and route specify hostnames,
@@ -1089,7 +2665,7 @@ spec:
                         the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
                         if the Protocol field is "HTTP", "TCP", or "UDP".
 
-                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        The association of SNIs to Certificate defined in ListenerTLSConfig is
                         defined based on the Hostname field for this listener.
 
                         The GatewayClass MUST use the longest matching SNI out of all
@@ -1176,6 +2752,7 @@ spec:
                             type: object
                           maxItems: 64
                           type: array
+                          x-kubernetes-list-type: atomic
                         mode:
                           default: Terminate
                           description: |-
@@ -1244,6 +2821,9 @@ spec:
                 - message: tls mode must be Terminate for protocol HTTPS
                   rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
                     == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: tls mode must be set for protocol TLS
+                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
+                    && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
                   rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
@@ -1254,6 +2834,421 @@ spec:
                   rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
                     == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
                     == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+              tls:
+                description: |-
+                  TLS specifies frontend and backend tls configuration for entire gateway.
+
+                  Support: Extended
+                properties:
+                  backend:
+                    description: |-
+                      Backend describes TLS configuration for gateway when connecting
+                      to backends.
+
+                      Note that this contains only details for the Gateway as a TLS client,
+                      and does _not_ imply behavior about how to choose which backend should
+                      get a TLS connection. That is determined by the presence of a BackendTLSPolicy.
+
+                      Support: Core
+                    properties:
+                      clientCertificateRef:
+                        description: |-
+                          ClientCertificateRef references an object that contains a client certificate
+                          and its associated private key. It can reference standard Kubernetes resources,
+                          i.e., Secret, or implementation-specific custom resources.
+
+                          A ClientCertificateRef is considered invalid if:
+
+                          * It refers to a resource that cannot be resolved (e.g., the referenced resource
+                            does not exist) or is misconfigured (e.g., a Secret does not contain the keys
+                            named `tls.crt` and `tls.key`). In this case, the `ResolvedRefs` condition
+                            on the Gateway MUST be set to False with the Reason `InvalidClientCertificateRef`
+                            and the Message of the Condition MUST indicate why the reference is invalid.
+
+                          * It refers to a resource in another namespace UNLESS there is a ReferenceGrant
+                            in the target namespace that allows the certificate to be attached.
+                            If a ReferenceGrant does not allow this reference, the `ResolvedRefs` condition
+                            on the Gateway MUST be set to False with the Reason `RefNotPermitted`.
+
+                          Implementations MAY choose to perform further validation of the certificate
+                          content (e.g., checking expiry or enforcing specific formats). In such cases,
+                          an implementation-specific Reason and Message MUST be set.
+
+                          Support: Core - Reference to a Kubernetes TLS Secret (with the type `kubernetes.io/tls`).
+                          Support: Implementation-specific - Other resource kinds or Secrets with a
+                          different type (e.g., `Opaque`).
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Secret
+                            description: Kind is kind of the referent. For example
+                              "Secret".
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referenced object. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  frontend:
+                    description: |-
+                      Frontend describes TLS config when client connects to Gateway.
+                      Support: Core
+                    properties:
+                      default:
+                        description: |-
+                          Default specifies the default client certificate validation configuration
+                          for all Listeners handling HTTPS traffic, unless a per-port configuration
+                          is defined.
+
+                          support: Core
+                        properties:
+                          validation:
+                            description: |-
+                              Validation holds configuration information for validating the frontend (client).
+                              Setting this field will result in mutual authentication when connecting to the gateway.
+                              In browsers this may result in a dialog appearing
+                              that requests a user to specify the client certificate.
+                              The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                              Support: Core
+                            properties:
+                              caCertificateRefs:
+                                description: |-
+                                  CACertificateRefs contains one or more references to Kubernetes
+                                  objects that contain a PEM-encoded TLS CA certificate bundle, which
+                                  is used as a trust anchor to validate the certificates presented by
+                                  the client.
+
+                                  A CACertificateRef is invalid if:
+
+                                  * It refers to a resource that cannot be resolved (e.g., the
+                                    referenced resource does not exist) or is misconfigured (e.g., a
+                                    ConfigMap does not contain a key named `ca.crt`). In this case, the
+                                    Reason on all matching HTTPS listeners must be set to `InvalidCACertificateRef`
+                                    and the Message of the Condition must indicate which reference is invalid and why.
+
+                                  * It refers to an unknown or unsupported kind of resource. In this
+                                    case, the Reason on all matching HTTPS listeners must be set to
+                                    `InvalidCACertificateKind` and the Message of the Condition must explain
+                                    which kind of resource is unknown or unsupported.
+
+                                  * It refers to a resource in another namespace UNLESS there is a
+                                    ReferenceGrant in the target namespace that allows the CA
+                                    certificate to be attached. If a ReferenceGrant does not allow this
+                                    reference, the `ResolvedRefs` on all matching HTTPS listeners condition
+                                    MUST be set with the Reason `RefNotPermitted`.
+
+                                  Implementations MAY choose to perform further validation of the
+                                  certificate content (e.g., checking expiry or enforcing specific formats).
+                                  In such cases, an implementation-specific Reason and Message MUST be set.
+
+                                  In all cases, the implementation MUST ensure that the `ResolvedRefs`
+                                  condition is set to `status: False` on all targeted listeners (i.e.,
+                                  listeners serving HTTPS on a matching port). The condition MUST
+                                  include a Reason and Message that indicate the cause of the error. If
+                                  ALL CACertificateRefs are invalid, the implementation MUST also ensure
+                                  the `Accepted` condition on the listener is set to `status: False`, with
+                                  the Reason `NoValidCACertificate`.
+                                  Implementations MAY choose to support attaching multiple CA certificates
+                                  to a listener, but this behavior is implementation-specific.
+
+                                  Support: Core - A single reference to a Kubernetes ConfigMap, with the
+                                  CA certificate in a key named `ca.crt`.
+
+                                  Support: Implementation-specific - More than one reference, other kinds
+                                  of resources, or a single reference that includes multiple certificates.
+                                items:
+                                  description: |-
+                                    ObjectReference identifies an API object including its namespace.
+
+                                    The API object must be valid in the cluster; the Group and Kind must
+                                    be registered in the cluster for this reference to be valid.
+
+                                    References to objects with invalid Group and Kind are not valid, and must
+                                    be rejected by the implementation, with appropriate Conditions set
+                                    on the containing object.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When set to the empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "ConfigMap" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of the referenced object. When unspecified, the local
+                                        namespace is inferred.
+
+                                        Note that when a namespace different than the local namespace is specified,
+                                        a ReferenceGrant object is required in the referent namespace to allow that
+                                        namespace's owner to accept the reference. See the ReferenceGrant
+                                        documentation for details.
+
+                                        Support: Core
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                maxItems: 8
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mode:
+                                default: AllowValidOnly
+                                description: |-
+                                  FrontendValidationMode defines the mode for validating the client certificate.
+                                  There are two possible modes:
+
+                                  - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                    the client presents a valid certificate. This certificate must successfully
+                                    pass validation against the CA certificates specified in `CACertificateRefs`.
+                                  - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                    even if the client certificate is not presented or fails verification.
+
+                                    This approach delegates client authorization to the backend and introduce
+                                    a significant security risk. It should be used in testing environments or
+                                    on a temporary basis in non-testing environments.
+
+                                  Defaults to AllowValidOnly.
+
+                                  Support: Core
+                                enum:
+                                - AllowValidOnly
+                                - AllowInsecureFallback
+                                type: string
+                            required:
+                            - caCertificateRefs
+                            type: object
+                        type: object
+                      perPort:
+                        description: |-
+                          PerPort specifies tls configuration assigned per port.
+                          Per port configuration is optional. Once set this configuration overrides
+                          the default configuration for all Listeners handling HTTPS traffic
+                          that match this port.
+                          Each override port requires a unique TLS configuration.
+
+                          support: Core
+                        items:
+                          properties:
+                            port:
+                              description: |-
+                                The Port indicates the Port Number to which the TLS configuration will be
+                                applied. This configuration will be applied to all Listeners handling HTTPS
+                                traffic that match this port.
+
+                                Support: Core
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            tls:
+                              description: |-
+                                TLS store the configuration that will be applied to all Listeners handling
+                                HTTPS traffic and matching given port.
+
+                                Support: Core
+                              properties:
+                                validation:
+                                  description: |-
+                                    Validation holds configuration information for validating the frontend (client).
+                                    Setting this field will result in mutual authentication when connecting to the gateway.
+                                    In browsers this may result in a dialog appearing
+                                    that requests a user to specify the client certificate.
+                                    The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                                    Support: Core
+                                  properties:
+                                    caCertificateRefs:
+                                      description: |-
+                                        CACertificateRefs contains one or more references to Kubernetes
+                                        objects that contain a PEM-encoded TLS CA certificate bundle, which
+                                        is used as a trust anchor to validate the certificates presented by
+                                        the client.
+
+                                        A CACertificateRef is invalid if:
+
+                                        * It refers to a resource that cannot be resolved (e.g., the
+                                          referenced resource does not exist) or is misconfigured (e.g., a
+                                          ConfigMap does not contain a key named `ca.crt`). In this case, the
+                                          Reason on all matching HTTPS listeners must be set to `InvalidCACertificateRef`
+                                          and the Message of the Condition must indicate which reference is invalid and why.
+
+                                        * It refers to an unknown or unsupported kind of resource. In this
+                                          case, the Reason on all matching HTTPS listeners must be set to
+                                          `InvalidCACertificateKind` and the Message of the Condition must explain
+                                          which kind of resource is unknown or unsupported.
+
+                                        * It refers to a resource in another namespace UNLESS there is a
+                                          ReferenceGrant in the target namespace that allows the CA
+                                          certificate to be attached. If a ReferenceGrant does not allow this
+                                          reference, the `ResolvedRefs` on all matching HTTPS listeners condition
+                                          MUST be set with the Reason `RefNotPermitted`.
+
+                                        Implementations MAY choose to perform further validation of the
+                                        certificate content (e.g., checking expiry or enforcing specific formats).
+                                        In such cases, an implementation-specific Reason and Message MUST be set.
+
+                                        In all cases, the implementation MUST ensure that the `ResolvedRefs`
+                                        condition is set to `status: False` on all targeted listeners (i.e.,
+                                        listeners serving HTTPS on a matching port). The condition MUST
+                                        include a Reason and Message that indicate the cause of the error. If
+                                        ALL CACertificateRefs are invalid, the implementation MUST also ensure
+                                        the `Accepted` condition on the listener is set to `status: False`, with
+                                        the Reason `NoValidCACertificate`.
+                                        Implementations MAY choose to support attaching multiple CA certificates
+                                        to a listener, but this behavior is implementation-specific.
+
+                                        Support: Core - A single reference to a Kubernetes ConfigMap, with the
+                                        CA certificate in a key named `ca.crt`.
+
+                                        Support: Implementation-specific - More than one reference, other kinds
+                                        of resources, or a single reference that includes multiple certificates.
+                                      items:
+                                        description: |-
+                                          ObjectReference identifies an API object including its namespace.
+
+                                          The API object must be valid in the cluster; the Group and Kind must
+                                          be registered in the cluster for this reference to be valid.
+
+                                          References to objects with invalid Group and Kind are not valid, and must
+                                          be rejected by the implementation, with appropriate Conditions set
+                                          on the containing object.
+                                        properties:
+                                          group:
+                                            description: |-
+                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                              When set to the empty string, core API group is inferred.
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            description: Kind is kind of the referent.
+                                              For example "ConfigMap" or "Service".
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of the referenced object. When unspecified, the local
+                                              namespace is inferred.
+
+                                              Note that when a namespace different than the local namespace is specified,
+                                              a ReferenceGrant object is required in the referent namespace to allow that
+                                              namespace's owner to accept the reference. See the ReferenceGrant
+                                              documentation for details.
+
+                                              Support: Core
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                        required:
+                                        - group
+                                        - kind
+                                        - name
+                                        type: object
+                                      maxItems: 8
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mode:
+                                      default: AllowValidOnly
+                                      description: |-
+                                        FrontendValidationMode defines the mode for validating the client certificate.
+                                        There are two possible modes:
+
+                                        - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                          the client presents a valid certificate. This certificate must successfully
+                                          pass validation against the CA certificates specified in `CACertificateRefs`.
+                                        - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                          even if the client certificate is not presented or fails verification.
+
+                                          This approach delegates client authorization to the backend and introduce
+                                          a significant security risk. It should be used in testing environments or
+                                          on a temporary basis in non-testing environments.
+
+                                        Defaults to AllowValidOnly.
+
+                                        Support: Core
+                                      enum:
+                                      - AllowValidOnly
+                                      - AllowInsecureFallback
+                                      type: string
+                                  required:
+                                  - caCertificateRefs
+                                  type: object
+                              type: object
+                          required:
+                          - port
+                          - tls
+                          type: object
+                        maxItems: 64
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Port for TLS configuration must be unique within
+                            the Gateway
+                          rule: self.all(t1, self.exists_one(t2, t1.port == t2.port))
+                    required:
+                    - default
+                    type: object
+                type: object
             required:
             - gatewayClassName
             - listeners
@@ -1274,7 +3269,7 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
 
@@ -1284,7 +3279,6 @@ spec:
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
-
                 items:
                   description: GatewayStatusAddress describes a network address that
                     is bound to a Gateway.
@@ -1329,6 +3323,21 @@ spec:
                       true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
+              attachedListenerSets:
+                description: |-
+                  AttachedListenerSets represents the total number of ListenerSets that have been
+                  successfully attached to this Gateway.
+
+                  A ListenerSet is successfully attached to a Gateway when all the following conditions are met:
+                  - The ListenerSet is selected by the Gateway's AllowedListeners field
+                  - The ListenerSet has a valid ParentRef selecting the Gateway
+                  - The ListenerSet's status has the condition "Accepted: true"
+
+                  Uses for this field include troubleshooting AttachedListenerSets attachment and
+                  measuring blast radius/impact of changes to a Gateway.
+                format: int32
+                type: integer
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
@@ -1433,8 +3442,11 @@ spec:
                         attachment semantics can be found in the documentation on the various
                         Route kinds ParentRefs fields). Listener or Route status does not impact
                         successful attachment, i.e. the AttachedRoutes field count MUST be set
-                        for Listeners with condition Accepted: false and MUST count successfully
-                        attached Routes that may themselves have Accepted: false conditions.
+                        for Listeners, even if the Accepted condition of an individual Listener is set
+                        to "False". The AttachedRoutes number represents the number of Routes with
+                        the Accepted condition set to "True" that have been attached to this Listener.
+                        Routes with any other value for the Accepted condition MUST NOT be included
+                        in this count.
 
                         Uses for this field include troubleshooting Route attachment and
                         measuring blast radius/impact of changes to a Listener.
@@ -1513,7 +3525,7 @@ spec:
                     supportedKinds:
                       description: |-
                         SupportedKinds is the list indicating the Kinds supported by this
-                        listener. This MUST represent the kinds an implementation supports for
+                        listener. This MUST represent the kinds supported by an implementation for
                         that Listener configuration.
 
                         If kinds are specified in Spec that are not supported, they MUST NOT
@@ -1542,11 +3554,11 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-type: atomic
                   required:
                   - attachedRoutes
                   - conditions
                   - name
-                  - supportedKinds
                   type: object
                 maxItems: 64
                 type: array
@@ -1602,11 +3614,11 @@ spec:
             description: Spec defines the desired state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
-                  indicate this in the associated entry in GatewayStatus.Addresses.
+                  indicate this in an associated entry in GatewayStatus.Conditions.
 
                   The Addresses field represents a request for the address(es) on the
                   "outside of the Gateway", that traffic bound for this Gateway will use.
@@ -1623,10 +3635,9 @@ spec:
                   GatewayStatus.Addresses.
 
                   Support: Extended
-
                 items:
-                  description: GatewayAddress describes an address that can be bound
-                    to a Gateway.
+                  description: GatewaySpecAddress describes an address that can be
+                    bound to a Gateway.
                   oneOf:
                   - properties:
                       type:
@@ -1651,30 +3662,114 @@ spec:
                       type: string
                     value:
                       description: |-
-                        Value of the address. The validity of the values will depend
-                        on the type and support by the controller.
+                        When a value is unspecified, an implementation SHOULD automatically
+                        assign an address matching the requested type if possible.
+
+                        If an implementation does not support an empty value, they MUST set the
+                        "Programmed" condition in status to False with a reason of "AddressNotAssigned".
 
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
-                      minLength: 1
                       type: string
-                  required:
-                  - value
                   type: object
                   x-kubernetes-validations:
-                  - message: Hostname value must only contain valid characters (matching
-                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
-                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                  - message: Hostname value must be empty or contain only valid characters
+                      (matching ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? (!has(self.value) || self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$""")):
                       true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: IPAddress values must be unique
-                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
-                    a2.type == a1.type && a2.value == a1.value) : true )'
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
                 - message: Hostname values must be unique
-                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
-                    a2.type == a1.type && a2.value == a1.value) : true )'
+                  rule: 'self.all(a1, a1.type == ''Hostname''  && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
+              allowedListeners:
+                description: |-
+                  AllowedListeners defines which ListenerSets can be attached to this Gateway.
+                  The default value is to allow no ListenerSets.
+                properties:
+                  namespaces:
+                    default:
+                      from: None
+                    description: |-
+                      Namespaces defines which namespaces ListenerSets can be attached to this Gateway.
+                      The default value is to allow no ListenerSets.
+                    properties:
+                      from:
+                        default: None
+                        description: |-
+                          From indicates where ListenerSets can attach to this Gateway. Possible
+                          values are:
+
+                          * Same: Only ListenerSets in the same namespace may be attached to this Gateway.
+                          * Selector: ListenerSets in namespaces selected by the selector may be attached to this Gateway.
+                          * All: ListenerSets in all namespaces may be attached to this Gateway.
+                          * None: Only listeners defined in the Gateway's spec are allowed
+
+                          The default value None
+                        enum:
+                        - All
+                        - Selector
+                        - Same
+                        - None
+                        type: string
+                      selector:
+                        description: |-
+                          Selector must be specified when From is set to "Selector". In that case,
+                          only ListenerSets in Namespaces matching this Selector will be selected by this
+                          Gateway. This field is ignored for other values of "From".
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                type: object
               gatewayClassName:
                 description: |-
                   GatewayClassName used for this Gateway. This is the name of a
@@ -1769,6 +3864,11 @@ spec:
                       the merging behavior is implementation specific.
                       It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
 
+                      If the referent cannot be found, refers to an unsupported kind, or when
+                      the data within that resource is malformed, the Gateway SHOULD be
+                      rejected with the "Accepted" status condition set to "False" and an
+                      "InvalidParameters" reason.
+
                       Support: Implementation-specific
                     properties:
                       group:
@@ -1799,6 +3899,8 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses.
                   At least one Listener MUST be specified.
 
+                  ## Distinct Listeners
+
                   Each Listener in a set of Listeners (for example, in a single Gateway)
                   MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
                   exactly one listener. (This section uses "set of Listeners" rather than
@@ -1810,55 +3912,76 @@ spec:
                   combination of Port, Protocol, and, if supported by the protocol, Hostname.
 
                   Some combinations of port, protocol, and TLS settings are considered
-                  Core support and MUST be supported by implementations based on their
-                  targeted conformance profile:
+                  Core support and MUST be supported by implementations based on the objects
+                  they support:
 
-                  HTTP Profile
+                  HTTPRoute
 
                   1. HTTPRoute, Port: 80, Protocol: HTTP
                   2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
 
-                  TLS Profile
+                  TLSRoute
 
                   1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
 
                   "Distinct" Listeners have the following property:
 
-                  The implementation can match inbound requests to a single distinct
-                  Listener. When multiple Listeners share values for fields (for
+                  **The implementation can match inbound requests to a single distinct
+                  Listener**.
+
+                  When multiple Listeners share values for fields (for
                   example, two Listeners with the same Port value), the implementation
                   can match requests to only one of the Listeners using other
                   Listener fields.
 
-                  For example, the following Listener scenarios are distinct:
+                  When multiple listeners have the same value for the Protocol field, then
+                  each of the Listeners with matching Protocol values MUST have different
+                  values for other fields.
 
-                  1. Multiple Listeners with the same Port that all use the "HTTP"
-                     Protocol that all have unique Hostname values.
-                  2. Multiple Listeners with the same Port that use either the "HTTPS" or
-                     "TLS" Protocol that all have unique Hostname values.
-                  3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
-                     with the same Protocol has the same Port value.
+                  The set of fields that MUST be different for a Listener differs per protocol.
+                  The following rules define the rules for what fields MUST be considered for
+                  Listeners to be distinct with each protocol currently defined in the
+                  Gateway API spec.
 
-                  Some fields in the Listener struct have possible values that affect
-                  whether the Listener is distinct. Hostname is particularly relevant
-                  for HTTP or HTTPS protocols.
+                  The set of listeners that all share a protocol value MUST have _different_
+                  values for _at least one_ of these fields to be distinct:
 
-                  When using the Hostname value to select between same-Port, same-Protocol
-                  Listeners, the Hostname value must be different on each Listener for the
-                  Listener to be distinct.
+                  * **HTTP, HTTPS, TLS**: Port, Hostname
+                  * **TCP, UDP**: Port
 
-                  When the Listeners are distinct based on Hostname, inbound request
+                  One **very** important rule to call out involves what happens when an
+                  implementation:
+
+                  * Supports TCP protocol Listeners, as well as HTTP, HTTPS, or TLS protocol
+                    Listeners, and
+                  * sees HTTP, HTTPS, or TLS protocols with the same `port` as one with TCP
+                    Protocol.
+
+                  In this case all the Listeners that share a port with the
+                  TCP Listener are not distinct and so MUST NOT be accepted.
+
+                  If an implementation does not support TCP Protocol Listeners, then the
+                  previous rule does not apply, and the TCP Listeners SHOULD NOT be
+                  accepted.
+
+                  Note that the `tls` field is not used for determining if a listener is distinct, because
+                  Listeners that _only_ differ on TLS config will still conflict in all cases.
+
+                  ### Listeners that are distinct only by Hostname
+
+                  When the Listeners are distinct based only on Hostname, inbound request
                   hostnames MUST match from the most specific to least specific Hostname
                   values to choose the correct Listener and its associated set of Routes.
 
-                  Exact matches must be processed before wildcard matches, and wildcard
-                  matches must be processed before fallback (empty Hostname value)
+                  Exact matches MUST be processed before wildcard matches, and wildcard
+                  matches MUST be processed before fallback (empty Hostname value)
                   matches. For example, `"foo.example.com"` takes precedence over
                   `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
 
                   Additionally, if there are multiple wildcard entries, more specific
                   wildcard entries must be processed before less specific wildcard entries.
                   For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+
                   The precise definition here is that the higher the number of dots in the
                   hostname to the right of the wildcard character, the higher the precedence.
 
@@ -1866,18 +3989,26 @@ spec:
                   the left, however, so `"*.example.com"` will match both
                   `"foo.bar.example.com"` _and_ `"bar.example.com"`.
 
+                  ## Handling indistinct Listeners
+
                   If a set of Listeners contains Listeners that are not distinct, then those
-                  Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                  Listeners are _Conflicted_, and the implementation MUST set the "Conflicted"
                   condition in the Listener Status to "True".
+
+                  The words "indistinct" and "conflicted" are considered equivalent for the
+                  purpose of this documentation.
 
                   Implementations MAY choose to accept a Gateway with some Conflicted
                   Listeners only if they only accept the partial Listener set that contains
-                  no Conflicted Listeners. To put this another way, implementations may
-                  accept a partial Listener set only if they throw out *all* the conflicting
-                  Listeners. No picking one of the conflicting listeners as the winner.
-                  This also means that the Gateway must have at least one non-conflicting
-                  Listener in this case, otherwise it violates the requirement that at
-                  least one Listener must be present.
+                  no Conflicted Listeners.
+
+                  Specifically, an implementation MAY accept a partial Listener set subject to
+                  the following rules:
+
+                  * The implementation MUST NOT pick one conflicting Listener as the winner.
+                    ALL indistinct Listeners must not be accepted for processing.
+                  * At least one distinct Listener MUST be present, or else the Gateway effectively
+                    contains _no_ Listeners, and must be rejected from processing as a whole.
 
                   The implementation MUST set a "ListenersNotValid" condition on the
                   Gateway Status when the Gateway contains Conflicted Listeners whether or
@@ -1886,7 +4017,25 @@ spec:
                   Accepted. Additionally, the Listener status for those listeners SHOULD
                   indicate which Listeners are conflicted and not Accepted.
 
-                  A Gateway's Listeners are considered "compatible" if:
+                  ## General Listener behavior
+
+                  Note that, for all distinct Listeners, requests SHOULD match at most one Listener.
+                  For example, if Listeners are defined for "foo.example.com" and "*.example.com", a
+                  request to "foo.example.com" SHOULD only be routed using routes attached
+                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+
+                  This concept is known as "Listener Isolation", and it is an Extended feature
+                  of Gateway API. Implementations that do not support Listener Isolation MUST
+                  clearly document this, and MUST NOT claim support for the
+                  `GatewayHTTPListenerIsolation` feature.
+
+                  Implementations that _do_ support Listener Isolation SHOULD claim support
+                  for the Extended `GatewayHTTPListenerIsolation` feature and pass the associated
+                  conformance tests.
+
+                  ## Compatible Listeners
+
+                  A Gateway's Listeners are considered _compatible_ if:
 
                   1. They are distinct.
                   2. The implementation can serve them in compliance with the Addresses
@@ -1901,15 +4050,10 @@ spec:
                   on the same address, or cannot mix HTTPS and generic TLS listens on the same port
                   would not consider those cases compatible, even though they are distinct.
 
-                  Note that requests SHOULD match at most one Listener. For example, if
-                  Listeners are defined for "foo.example.com" and "*.example.com", a
-                  request to "foo.example.com" SHOULD only be routed using routes attached
-                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
-                  This concept is known as "Listener Isolation". Implementations that do
-                  not support Listener Isolation MUST clearly document this.
-
                   Implementations MAY merge separate Gateways onto a single set of
                   Addresses if all Listeners across all Gateways are compatible.
+
+                  In a future release the MinItems=1 requirement MAY be dropped.
 
                   Support: Core
                 items:
@@ -1981,6 +4125,7 @@ spec:
                             type: object
                           maxItems: 8
                           type: array
+                          x-kubernetes-list-type: atomic
                         namespaces:
                           default:
                             from: Same
@@ -2072,10 +4217,31 @@ spec:
 
                         * TLS: The Listener Hostname MUST match the SNI.
                         * HTTP: The Listener Hostname MUST match the Host header of the request.
-                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
-                          protocol layers as described above. If an implementation does not
-                          ensure that both the SNI and Host header match the Listener hostname,
-                          it MUST clearly document that.
+                        * HTTPS: The Listener Hostname SHOULD match both the SNI and Host header.
+                          Note that this does not require the SNI and Host header to be the same.
+                          The semantics of this are described in more detail below.
+
+                        To ensure security, Section 11.1 of RFC-6066 emphasizes that server
+                        implementations that rely on SNI hostname matching MUST also verify
+                        hostnames within the application protocol.
+
+                        Section 9.1.2 of RFC-7540 provides a mechanism for servers to reject the
+                        reuse of a connection by responding with the HTTP 421 Misdirected Request
+                        status code. This indicates that the origin server has rejected the
+                        request because it appears to have been misdirected.
+
+                        To detect misdirected requests, Gateways SHOULD match the authority of
+                        the requests with all the SNI hostname(s) configured across all the
+                        Gateway Listeners on the same port and protocol:
+
+                        * If another Listener has an exact match or more specific wildcard entry,
+                          the Gateway SHOULD return a 421.
+                        * If the current Listener (selected by SNI matching during ClientHello)
+                          does not match the Host:
+                            * If another Listener does match the Host, the Gateway SHOULD return a
+                              421.
+                            * If no other Listener matches the Host, the Gateway MUST return a
+                              404.
 
                         For HTTPRoute and TLSRoute resources, there is an interaction with the
                         `spec.hostnames` array. When both listener and route specify hostnames,
@@ -2127,7 +4293,7 @@ spec:
                         the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
                         if the Protocol field is "HTTP", "TCP", or "UDP".
 
-                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        The association of SNIs to Certificate defined in ListenerTLSConfig is
                         defined based on the Hostname field for this listener.
 
                         The GatewayClass MUST use the longest matching SNI out of all
@@ -2214,6 +4380,7 @@ spec:
                             type: object
                           maxItems: 64
                           type: array
+                          x-kubernetes-list-type: atomic
                         mode:
                           default: Terminate
                           description: |-
@@ -2282,6 +4449,9 @@ spec:
                 - message: tls mode must be Terminate for protocol HTTPS
                   rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
                     == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: tls mode must be set for protocol TLS
+                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
+                    && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
                   rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
@@ -2292,6 +4462,421 @@ spec:
                   rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
                     == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
                     == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+              tls:
+                description: |-
+                  TLS specifies frontend and backend tls configuration for entire gateway.
+
+                  Support: Extended
+                properties:
+                  backend:
+                    description: |-
+                      Backend describes TLS configuration for gateway when connecting
+                      to backends.
+
+                      Note that this contains only details for the Gateway as a TLS client,
+                      and does _not_ imply behavior about how to choose which backend should
+                      get a TLS connection. That is determined by the presence of a BackendTLSPolicy.
+
+                      Support: Core
+                    properties:
+                      clientCertificateRef:
+                        description: |-
+                          ClientCertificateRef references an object that contains a client certificate
+                          and its associated private key. It can reference standard Kubernetes resources,
+                          i.e., Secret, or implementation-specific custom resources.
+
+                          A ClientCertificateRef is considered invalid if:
+
+                          * It refers to a resource that cannot be resolved (e.g., the referenced resource
+                            does not exist) or is misconfigured (e.g., a Secret does not contain the keys
+                            named `tls.crt` and `tls.key`). In this case, the `ResolvedRefs` condition
+                            on the Gateway MUST be set to False with the Reason `InvalidClientCertificateRef`
+                            and the Message of the Condition MUST indicate why the reference is invalid.
+
+                          * It refers to a resource in another namespace UNLESS there is a ReferenceGrant
+                            in the target namespace that allows the certificate to be attached.
+                            If a ReferenceGrant does not allow this reference, the `ResolvedRefs` condition
+                            on the Gateway MUST be set to False with the Reason `RefNotPermitted`.
+
+                          Implementations MAY choose to perform further validation of the certificate
+                          content (e.g., checking expiry or enforcing specific formats). In such cases,
+                          an implementation-specific Reason and Message MUST be set.
+
+                          Support: Core - Reference to a Kubernetes TLS Secret (with the type `kubernetes.io/tls`).
+                          Support: Implementation-specific - Other resource kinds or Secrets with a
+                          different type (e.g., `Opaque`).
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Secret
+                            description: Kind is kind of the referent. For example
+                              "Secret".
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referenced object. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  frontend:
+                    description: |-
+                      Frontend describes TLS config when client connects to Gateway.
+                      Support: Core
+                    properties:
+                      default:
+                        description: |-
+                          Default specifies the default client certificate validation configuration
+                          for all Listeners handling HTTPS traffic, unless a per-port configuration
+                          is defined.
+
+                          support: Core
+                        properties:
+                          validation:
+                            description: |-
+                              Validation holds configuration information for validating the frontend (client).
+                              Setting this field will result in mutual authentication when connecting to the gateway.
+                              In browsers this may result in a dialog appearing
+                              that requests a user to specify the client certificate.
+                              The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                              Support: Core
+                            properties:
+                              caCertificateRefs:
+                                description: |-
+                                  CACertificateRefs contains one or more references to Kubernetes
+                                  objects that contain a PEM-encoded TLS CA certificate bundle, which
+                                  is used as a trust anchor to validate the certificates presented by
+                                  the client.
+
+                                  A CACertificateRef is invalid if:
+
+                                  * It refers to a resource that cannot be resolved (e.g., the
+                                    referenced resource does not exist) or is misconfigured (e.g., a
+                                    ConfigMap does not contain a key named `ca.crt`). In this case, the
+                                    Reason on all matching HTTPS listeners must be set to `InvalidCACertificateRef`
+                                    and the Message of the Condition must indicate which reference is invalid and why.
+
+                                  * It refers to an unknown or unsupported kind of resource. In this
+                                    case, the Reason on all matching HTTPS listeners must be set to
+                                    `InvalidCACertificateKind` and the Message of the Condition must explain
+                                    which kind of resource is unknown or unsupported.
+
+                                  * It refers to a resource in another namespace UNLESS there is a
+                                    ReferenceGrant in the target namespace that allows the CA
+                                    certificate to be attached. If a ReferenceGrant does not allow this
+                                    reference, the `ResolvedRefs` on all matching HTTPS listeners condition
+                                    MUST be set with the Reason `RefNotPermitted`.
+
+                                  Implementations MAY choose to perform further validation of the
+                                  certificate content (e.g., checking expiry or enforcing specific formats).
+                                  In such cases, an implementation-specific Reason and Message MUST be set.
+
+                                  In all cases, the implementation MUST ensure that the `ResolvedRefs`
+                                  condition is set to `status: False` on all targeted listeners (i.e.,
+                                  listeners serving HTTPS on a matching port). The condition MUST
+                                  include a Reason and Message that indicate the cause of the error. If
+                                  ALL CACertificateRefs are invalid, the implementation MUST also ensure
+                                  the `Accepted` condition on the listener is set to `status: False`, with
+                                  the Reason `NoValidCACertificate`.
+                                  Implementations MAY choose to support attaching multiple CA certificates
+                                  to a listener, but this behavior is implementation-specific.
+
+                                  Support: Core - A single reference to a Kubernetes ConfigMap, with the
+                                  CA certificate in a key named `ca.crt`.
+
+                                  Support: Implementation-specific - More than one reference, other kinds
+                                  of resources, or a single reference that includes multiple certificates.
+                                items:
+                                  description: |-
+                                    ObjectReference identifies an API object including its namespace.
+
+                                    The API object must be valid in the cluster; the Group and Kind must
+                                    be registered in the cluster for this reference to be valid.
+
+                                    References to objects with invalid Group and Kind are not valid, and must
+                                    be rejected by the implementation, with appropriate Conditions set
+                                    on the containing object.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When set to the empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "ConfigMap" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of the referenced object. When unspecified, the local
+                                        namespace is inferred.
+
+                                        Note that when a namespace different than the local namespace is specified,
+                                        a ReferenceGrant object is required in the referent namespace to allow that
+                                        namespace's owner to accept the reference. See the ReferenceGrant
+                                        documentation for details.
+
+                                        Support: Core
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                maxItems: 8
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mode:
+                                default: AllowValidOnly
+                                description: |-
+                                  FrontendValidationMode defines the mode for validating the client certificate.
+                                  There are two possible modes:
+
+                                  - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                    the client presents a valid certificate. This certificate must successfully
+                                    pass validation against the CA certificates specified in `CACertificateRefs`.
+                                  - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                    even if the client certificate is not presented or fails verification.
+
+                                    This approach delegates client authorization to the backend and introduce
+                                    a significant security risk. It should be used in testing environments or
+                                    on a temporary basis in non-testing environments.
+
+                                  Defaults to AllowValidOnly.
+
+                                  Support: Core
+                                enum:
+                                - AllowValidOnly
+                                - AllowInsecureFallback
+                                type: string
+                            required:
+                            - caCertificateRefs
+                            type: object
+                        type: object
+                      perPort:
+                        description: |-
+                          PerPort specifies tls configuration assigned per port.
+                          Per port configuration is optional. Once set this configuration overrides
+                          the default configuration for all Listeners handling HTTPS traffic
+                          that match this port.
+                          Each override port requires a unique TLS configuration.
+
+                          support: Core
+                        items:
+                          properties:
+                            port:
+                              description: |-
+                                The Port indicates the Port Number to which the TLS configuration will be
+                                applied. This configuration will be applied to all Listeners handling HTTPS
+                                traffic that match this port.
+
+                                Support: Core
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            tls:
+                              description: |-
+                                TLS store the configuration that will be applied to all Listeners handling
+                                HTTPS traffic and matching given port.
+
+                                Support: Core
+                              properties:
+                                validation:
+                                  description: |-
+                                    Validation holds configuration information for validating the frontend (client).
+                                    Setting this field will result in mutual authentication when connecting to the gateway.
+                                    In browsers this may result in a dialog appearing
+                                    that requests a user to specify the client certificate.
+                                    The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                                    Support: Core
+                                  properties:
+                                    caCertificateRefs:
+                                      description: |-
+                                        CACertificateRefs contains one or more references to Kubernetes
+                                        objects that contain a PEM-encoded TLS CA certificate bundle, which
+                                        is used as a trust anchor to validate the certificates presented by
+                                        the client.
+
+                                        A CACertificateRef is invalid if:
+
+                                        * It refers to a resource that cannot be resolved (e.g., the
+                                          referenced resource does not exist) or is misconfigured (e.g., a
+                                          ConfigMap does not contain a key named `ca.crt`). In this case, the
+                                          Reason on all matching HTTPS listeners must be set to `InvalidCACertificateRef`
+                                          and the Message of the Condition must indicate which reference is invalid and why.
+
+                                        * It refers to an unknown or unsupported kind of resource. In this
+                                          case, the Reason on all matching HTTPS listeners must be set to
+                                          `InvalidCACertificateKind` and the Message of the Condition must explain
+                                          which kind of resource is unknown or unsupported.
+
+                                        * It refers to a resource in another namespace UNLESS there is a
+                                          ReferenceGrant in the target namespace that allows the CA
+                                          certificate to be attached. If a ReferenceGrant does not allow this
+                                          reference, the `ResolvedRefs` on all matching HTTPS listeners condition
+                                          MUST be set with the Reason `RefNotPermitted`.
+
+                                        Implementations MAY choose to perform further validation of the
+                                        certificate content (e.g., checking expiry or enforcing specific formats).
+                                        In such cases, an implementation-specific Reason and Message MUST be set.
+
+                                        In all cases, the implementation MUST ensure that the `ResolvedRefs`
+                                        condition is set to `status: False` on all targeted listeners (i.e.,
+                                        listeners serving HTTPS on a matching port). The condition MUST
+                                        include a Reason and Message that indicate the cause of the error. If
+                                        ALL CACertificateRefs are invalid, the implementation MUST also ensure
+                                        the `Accepted` condition on the listener is set to `status: False`, with
+                                        the Reason `NoValidCACertificate`.
+                                        Implementations MAY choose to support attaching multiple CA certificates
+                                        to a listener, but this behavior is implementation-specific.
+
+                                        Support: Core - A single reference to a Kubernetes ConfigMap, with the
+                                        CA certificate in a key named `ca.crt`.
+
+                                        Support: Implementation-specific - More than one reference, other kinds
+                                        of resources, or a single reference that includes multiple certificates.
+                                      items:
+                                        description: |-
+                                          ObjectReference identifies an API object including its namespace.
+
+                                          The API object must be valid in the cluster; the Group and Kind must
+                                          be registered in the cluster for this reference to be valid.
+
+                                          References to objects with invalid Group and Kind are not valid, and must
+                                          be rejected by the implementation, with appropriate Conditions set
+                                          on the containing object.
+                                        properties:
+                                          group:
+                                            description: |-
+                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                              When set to the empty string, core API group is inferred.
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            description: Kind is kind of the referent.
+                                              For example "ConfigMap" or "Service".
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of the referenced object. When unspecified, the local
+                                              namespace is inferred.
+
+                                              Note that when a namespace different than the local namespace is specified,
+                                              a ReferenceGrant object is required in the referent namespace to allow that
+                                              namespace's owner to accept the reference. See the ReferenceGrant
+                                              documentation for details.
+
+                                              Support: Core
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                        required:
+                                        - group
+                                        - kind
+                                        - name
+                                        type: object
+                                      maxItems: 8
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mode:
+                                      default: AllowValidOnly
+                                      description: |-
+                                        FrontendValidationMode defines the mode for validating the client certificate.
+                                        There are two possible modes:
+
+                                        - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                          the client presents a valid certificate. This certificate must successfully
+                                          pass validation against the CA certificates specified in `CACertificateRefs`.
+                                        - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                          even if the client certificate is not presented or fails verification.
+
+                                          This approach delegates client authorization to the backend and introduce
+                                          a significant security risk. It should be used in testing environments or
+                                          on a temporary basis in non-testing environments.
+
+                                        Defaults to AllowValidOnly.
+
+                                        Support: Core
+                                      enum:
+                                      - AllowValidOnly
+                                      - AllowInsecureFallback
+                                      type: string
+                                  required:
+                                  - caCertificateRefs
+                                  type: object
+                              type: object
+                          required:
+                          - port
+                          - tls
+                          type: object
+                        maxItems: 64
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Port for TLS configuration must be unique within
+                            the Gateway
+                          rule: self.all(t1, self.exists_one(t2, t1.port == t2.port))
+                    required:
+                    - default
+                    type: object
+                type: object
             required:
             - gatewayClassName
             - listeners
@@ -2312,7 +4897,7 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
 
@@ -2322,7 +4907,6 @@ spec:
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
-
                 items:
                   description: GatewayStatusAddress describes a network address that
                     is bound to a Gateway.
@@ -2367,6 +4951,21 @@ spec:
                       true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
+              attachedListenerSets:
+                description: |-
+                  AttachedListenerSets represents the total number of ListenerSets that have been
+                  successfully attached to this Gateway.
+
+                  A ListenerSet is successfully attached to a Gateway when all the following conditions are met:
+                  - The ListenerSet is selected by the Gateway's AllowedListeners field
+                  - The ListenerSet has a valid ParentRef selecting the Gateway
+                  - The ListenerSet's status has the condition "Accepted: true"
+
+                  Uses for this field include troubleshooting AttachedListenerSets attachment and
+                  measuring blast radius/impact of changes to a Gateway.
+                format: int32
+                type: integer
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
@@ -2471,8 +5070,11 @@ spec:
                         attachment semantics can be found in the documentation on the various
                         Route kinds ParentRefs fields). Listener or Route status does not impact
                         successful attachment, i.e. the AttachedRoutes field count MUST be set
-                        for Listeners with condition Accepted: false and MUST count successfully
-                        attached Routes that may themselves have Accepted: false conditions.
+                        for Listeners, even if the Accepted condition of an individual Listener is set
+                        to "False". The AttachedRoutes number represents the number of Routes with
+                        the Accepted condition set to "True" that have been attached to this Listener.
+                        Routes with any other value for the Accepted condition MUST NOT be included
+                        in this count.
 
                         Uses for this field include troubleshooting Route attachment and
                         measuring blast radius/impact of changes to a Listener.
@@ -2551,7 +5153,7 @@ spec:
                     supportedKinds:
                       description: |-
                         SupportedKinds is the list indicating the Kinds supported by this
-                        listener. This MUST represent the kinds an implementation supports for
+                        listener. This MUST represent the kinds supported by an implementation for
                         that Listener configuration.
 
                         If kinds are specified in Spec that are not supported, they MUST NOT
@@ -2580,11 +5182,11 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-type: atomic
                   required:
                   - attachedRoutes
                   - conditions
                   - name
-                  - supportedKinds
                   type: object
                 maxItems: 64
                 type: array
@@ -2613,10 +5215,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
-  creationTimestamp: null
   name: grpcroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -2762,8 +5363,9 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -2814,12 +5416,6 @@ spec:
                   allowed by something in the namespace they are referring to. For example,
                   Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                   generic way to enable other kinds of cross-namespace reference.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -2881,8 +5477,6 @@ spec:
                         Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
 
-
-
                         Support: Core
                       maxLength: 63
                       minLength: 1
@@ -2900,8 +5494,6 @@ spec:
                         as opposed to a listener(s) whose port(s) may be changed. When both Port
                         and SectionName are specified, the name and port of the selected listener
                         must match both specified values.
-
-
 
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
@@ -2955,6 +5547,7 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName must be specified when parentRefs includes
                     2 or more references to the same parent
@@ -2976,9 +5569,7 @@ spec:
                     == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
                     == p2.sectionName))))
               rules:
-                description: |+
-                  Rules are a list of GRPC matchers, filters and actions.
-
+                description: Rules are a list of GRPC matchers, filters and actions.
                 items:
                   description: |-
                     GRPCRouteRule defines the semantics for matching a gRPC request based on
@@ -3023,24 +5614,6 @@ spec:
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
-
-                          <gateway:experimental:description>
-
-                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
-                          honor the appProtocol field if it is set for the target Service Port.
-
-                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
-                          Standard Application Protocols defined in KEP-3726.
-
-                          If a Service appProtocol isn't specified, an implementation MAY infer the
-                          backend protocol through its own means. Implementations MAY infer the
-                          protocol from the Route type referring to the backend Service.
-
-                          If a Route is not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations MUST set the
-                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
@@ -3126,7 +5699,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3201,7 +5774,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3229,7 +5802,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
@@ -3239,7 +5812,6 @@ spec:
                                     backends.
 
                                     Support: Extended
-
                                   properties:
                                     backendRef:
                                       description: |-
@@ -3334,9 +5906,49 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |-
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |-
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
                                   required:
                                   - backendRef
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
                                 responseHeaderModifier:
                                   description: |-
                                     ResponseHeaderModifier defines a schema for a filter that modifies response
@@ -3370,7 +5982,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3445,7 +6057,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3473,7 +6085,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 type:
-                                  description: |+
+                                  description: |-
                                     Type identifies the type of filter to apply. As with other API fields,
                                     types are classified into three conformance levels:
 
@@ -3498,7 +6110,6 @@ spec:
                                     If a reference to a custom filter type cannot be resolved, the filter
                                     MUST NOT be skipped. Instead, requests that would have been processed by
                                     that filter MUST receive a HTTP error response.
-
                                   enum:
                                   - ResponseHeaderModifier
                                   - RequestHeaderModifier
@@ -3540,6 +6151,7 @@ spec:
                                 rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
                             maxItems: 16
                             type: array
+                            x-kubernetes-list-type: atomic
                             x-kubernetes-validations:
                             - message: RequestHeaderModifier filter cannot be repeated
                               rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
@@ -3636,6 +6248,7 @@ spec:
                             ? has(self.port) : true'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                     filters:
                       description: |-
                         Filters define the filters that are applied to requests that match
@@ -3655,7 +6268,7 @@ spec:
                         Specifying the same filter multiple times is not supported unless explicitly
                         indicated in the filter.
 
-                        If an implementation can not support a combination of filters, it must clearly
+                        If an implementation cannot support a combination of filters, it must clearly
                         document that limitation. In cases where incompatible or unsupported
                         filters are specified and cause the `Accepted` condition to be set to status
                         `False`, implementations may use the `IncompatibleFilters` reason to specify
@@ -3738,7 +6351,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -3812,7 +6425,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -3840,7 +6453,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
@@ -3850,7 +6463,6 @@ spec:
                               backends.
 
                               Support: Extended
-
                             properties:
                               backendRef:
                                 description: |-
@@ -3945,9 +6557,49 @@ spec:
                                 - message: Must have port for Service reference
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
+                              fraction:
+                                description: |-
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |-
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
                             required:
                             - backendRef
                             type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
                           responseHeaderModifier:
                             description: |-
                               ResponseHeaderModifier defines a schema for a filter that modifies response
@@ -3980,7 +6632,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -4054,7 +6706,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -4082,7 +6734,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           type:
-                            description: |+
+                            description: |-
                               Type identifies the type of filter to apply. As with other API fields,
                               types are classified into three conformance levels:
 
@@ -4107,7 +6759,6 @@ spec:
                               If a reference to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have been processed by
                               that filter MUST receive a HTTP error response.
-
                             enum:
                             - ResponseHeaderModifier
                             - RequestHeaderModifier
@@ -4148,6 +6799,7 @@ spec:
                           rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                       x-kubernetes-validations:
                       - message: RequestHeaderModifier filter cannot be repeated
                         rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
@@ -4220,8 +6872,8 @@ spec:
                             - method:
                               type: Exact
                               service: "foo"
-                              headers:
-                            - name: "version"
+                            - headers:
+                              name: "version"
                               value "v1"
 
                           ```
@@ -4323,11 +6975,22 @@ spec:
                                 has(self.method) ? self.method.matches(r"""^[A-Za-z_][A-Za-z_0-9]*$"""):
                                 true'
                         type: object
-                      maxItems: 8
+                      maxItems: 64
                       type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: While 16 rules and 64 matches per rule are allowed, the
                     total number of matches across all rules in a route must be less
@@ -4392,9 +7055,9 @@ spec:
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
 
-                        * The Route refers to a non-existent parent.
+                        * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -4526,8 +7189,6 @@ spec:
                             Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                             generic way to enable any other kind of cross-namespace reference.
 
-
-
                             Support: Core
                           maxLength: 63
                           minLength: 1
@@ -4545,8 +7206,6 @@ spec:
                             as opposed to a listener(s) whose port(s) may be changed. When both Port
                             and SectionName are specified, the name and port of the selected listener
                             must match both specified values.
-
-
 
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
@@ -4599,14 +7258,18 @@ spec:
                       - name
                       type: object
                   required:
+                  - conditions
                   - controllerName
                   - parentRef
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - parents
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -4626,10 +7289,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
-  creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -4755,8 +7417,9 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -4807,12 +7470,6 @@ spec:
                   allowed by something in the namespace they are referring to. For example,
                   Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                   generic way to enable other kinds of cross-namespace reference.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -4874,8 +7531,6 @@ spec:
                         Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
 
-
-
                         Support: Core
                       maxLength: 63
                       minLength: 1
@@ -4893,8 +7548,6 @@ spec:
                         as opposed to a listener(s) whose port(s) may be changed. When both Port
                         and SectionName are specified, the name and port of the selected listener
                         must match both specified values.
-
-
 
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
@@ -4948,6 +7601,7 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName must be specified when parentRefs includes
                     2 or more references to the same parent
@@ -4974,9 +7628,7 @@ spec:
                   - path:
                       type: PathPrefix
                       value: /
-                description: |+
-                  Rules are a list of HTTP matchers, filters and actions.
-
+                description: Rules are a list of HTTP matchers, filters and actions.
                 items:
                   description: |-
                     HTTPRouteRule defines semantics for matching an HTTP request based on
@@ -5028,24 +7680,6 @@ spec:
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
-
-                          <gateway:experimental:description>
-
-                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
-                          honor the appProtocol field if it is set for the target Service Port.
-
-                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
-                          Standard Application Protocols defined in KEP-3726.
-
-                          If a Service appProtocol isn't specified, an implementation MAY infer the
-                          backend protocol through its own means. Implementations MAY infer the
-                          protocol from the Route type referring to the backend Service.
-
-                          If a Route is not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations MUST set the
-                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
@@ -5063,6 +7697,316 @@ spec:
                                 authentication strategies, rate-limiting, and traffic shaping. API
                                 guarantee/conformance is defined based on the type of the filter.
                               properties:
+                                cors:
+                                  description: |-
+                                    CORS defines a schema for a filter that responds to the
+                                    cross-origin request based on HTTP response header.
+
+                                    Support: Extended
+                                  properties:
+                                    allowCredentials:
+                                      description: |-
+                                        AllowCredentials indicates whether the actual cross-origin request allows
+                                        to include credentials.
+
+                                        When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                        response header with value true (case-sensitive).
+
+                                        When set to false or omitted the gateway will omit the header
+                                        `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                        behavior).
+
+                                        Support: Extended
+                                      type: boolean
+                                    allowHeaders:
+                                      description: |-
+                                        AllowHeaders indicates which HTTP request headers are supported for
+                                        accessing the requested resource.
+
+                                        Header names are not case-sensitive.
+
+                                        Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                        response header are separated by a comma (",").
+
+                                        When the `AllowHeaders` field is configured with one or more headers, the
+                                        gateway must return the `Access-Control-Allow-Headers` response header
+                                        which value is present in the `AllowHeaders` field.
+
+                                        If any header name in the `Access-Control-Request-Headers` request header
+                                        is not included in the list of header names specified by the response
+                                        header `Access-Control-Allow-Headers`, it will present an error on the
+                                        client side.
+
+                                        If any header name in the `Access-Control-Allow-Headers` response header
+                                        does not recognize by the client, it will also occur an error on the
+                                        client side.
+
+                                        A wildcard indicates that the requests with all HTTP headers are allowed.
+                                        If config contains the wildcard "*" in allowHeaders and the request is
+                                        not credentialed, the `Access-Control-Allow-Headers` response header
+                                        can either use the `*` wildcard or the value of
+                                        Access-Control-Request-Headers from the request.
+
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Headers` response header. When
+                                        also the `AllowCredentials` field is true and `AllowHeaders` field
+                                        is specified with the `*` wildcard, the gateway must specify one or more
+                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                        header. The value of the header `Access-Control-Allow-Headers` is same as
+                                        the `Access-Control-Request-Headers` header provided by the client. If
+                                        the header `Access-Control-Request-Headers` is not included in the
+                                        request, the gateway will omit the `Access-Control-Allow-Headers`
+                                        response header, instead of specifying the `*` wildcard.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          HTTPHeaderName is the name of an HTTP header.
+
+                                          Valid values include:
+
+                                          * "Authorization"
+                                          * "Set-Cookie"
+
+                                          Invalid values include:
+
+                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                              headers are not currently supported by this type.
+                                            - "/invalid" - "/ " is an invalid character
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowHeaders cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowMethods:
+                                      description: |-
+                                        AllowMethods indicates which HTTP methods are supported for accessing the
+                                        requested resource.
+
+                                        Valid values are any method defined by RFC9110, along with the special
+                                        value `*`, which represents all HTTP methods are allowed.
+
+                                        Method names are case-sensitive, so these values are also case-sensitive.
+                                        (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                        Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                        response header are separated by a comma (",").
+
+                                        A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                        CORS-safelisted methods are always allowed, regardless of whether they
+                                        are specified in the `AllowMethods` field.
+
+                                        When the `AllowMethods` field is configured with one or more methods, the
+                                        gateway must return the `Access-Control-Allow-Methods` response header
+                                        which value is present in the `AllowMethods` field.
+
+                                        If the HTTP method of the `Access-Control-Request-Method` request header
+                                        is not included in the list of methods specified by the response header
+                                        `Access-Control-Allow-Methods`, it will present an error on the client
+                                        side.
+
+                                        If config contains the wildcard "*" in allowMethods and the request is
+                                        not credentialed, the `Access-Control-Allow-Methods` response header
+                                        can either use the `*` wildcard or the value of
+                                        Access-Control-Request-Method from the request.
+
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Methods` response header. When
+                                        also the `AllowCredentials` field is true and `AllowMethods` field
+                                        specified with the `*` wildcard, the gateway must specify one HTTP method
+                                        in the value of the Access-Control-Allow-Methods response header. The
+                                        value of the header `Access-Control-Allow-Methods` is same as the
+                                        `Access-Control-Request-Method` header provided by the client. If the
+                                        header `Access-Control-Request-Method` is not included in the request,
+                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                        instead of specifying the `*` wildcard.
+
+                                        Support: Extended
+                                      items:
+                                        enum:
+                                        - GET
+                                        - HEAD
+                                        - POST
+                                        - PUT
+                                        - DELETE
+                                        - CONNECT
+                                        - OPTIONS
+                                        - TRACE
+                                        - PATCH
+                                        - '*'
+                                        type: string
+                                      maxItems: 9
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowMethods cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowOrigins:
+                                      description: |-
+                                        AllowOrigins indicates whether the response can be shared with requested
+                                        resource from the given `Origin`.
+
+                                        The `Origin` consists of a scheme and a host, with an optional port, and
+                                        takes the form `<scheme>://<host>(:<port>)`.
+
+                                        Valid values for scheme are: `http` and `https`.
+
+                                        Valid values for port are any integer between 1 and 65535 (the list of
+                                        available TCP/UDP ports). Note that, if not included, port `80` is
+                                        assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                        origins. This may affect origin matching.
+
+                                        The host part of the origin may contain the wildcard character `*`. These
+                                        wildcard characters behave as follows:
+
+                                        * `*` is a greedy match to the _left_, including any number of
+                                          DNS labels to the left of its position. This also means that
+                                          `*` will include any number of period `.` characters to the
+                                          left of its position.
+                                        * A wildcard by itself matches all hosts.
+
+                                        An origin value that includes _only_ the `*` character indicates requests
+                                        from all `Origin`s are allowed.
+
+                                        When the `AllowOrigins` field is configured with multiple origins, it
+                                        means the server supports clients from multiple origins. If the request
+                                        `Origin` matches the configured allowed origins, the gateway must return
+                                        the given `Origin` and sets value of the header
+                                        `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                        client.
+
+                                        The status code of a successful response to a "preflight" request is
+                                        always an OK status (i.e., 204 or 200).
+
+                                        If the request `Origin` does not match the configured allowed origins,
+                                        the gateway returns 204/200 response but doesn't set the relevant
+                                        cross-origin response headers. Alternatively, the gateway responds with
+                                        403 status to the "preflight" request is denied, coupled with omitting
+                                        the CORS headers. The cross-origin request fails on the client side.
+                                        Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                        Conversely, if the request `Origin` matches one of the configured
+                                        allowed origins, the gateway sets the response header
+                                        `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                        header provided by the client.
+
+                                        When config has the wildcard ("*") in allowOrigins, and the request
+                                        is not credentialed (e.g., it is a preflight request), the
+                                        `Access-Control-Allow-Origin` response header either contains the
+                                        wildcard as well or the Origin from the request.
+
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Origin` response header. When
+                                        also the `AllowCredentials` field is true and `AllowOrigins` field
+                                        specified with the `*` wildcard, the gateway must return a single origin
+                                        in the value of the `Access-Control-Allow-Origin` response header,
+                                        instead of specifying the `*` wildcard. The value of the header
+                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                        the client.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                          encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                          scheme ("http" or "https") and a scheme-specific-part, or it should be a single '*' character.
+                                          URIs that include an authority MUST include a fully qualified domain name or
+                                          IP address as the host.
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowOrigins cannot contain '*' alongside
+                                          other origins
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    exposeHeaders:
+                                      description: |-
+                                        ExposeHeaders indicates which HTTP response headers can be exposed
+                                        to client-side scripts in response to a cross-origin request.
+
+                                        A CORS-safelisted response header is an HTTP header in a CORS response
+                                        that it is considered safe to expose to the client scripts.
+                                        The CORS-safelisted response headers include the following headers:
+                                        `Cache-Control`
+                                        `Content-Language`
+                                        `Content-Length`
+                                        `Content-Type`
+                                        `Expires`
+                                        `Last-Modified`
+                                        `Pragma`
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                        The CORS-safelisted response headers are exposed to client by default.
+
+                                        When an HTTP header name is specified using the `ExposeHeaders` field,
+                                        this additional header will be exposed as part of the response to the
+                                        client.
+
+                                        Header names are not case-sensitive.
+
+                                        Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                        response header are separated by a comma (",").
+
+                                        A wildcard indicates that the responses with all HTTP headers are exposed
+                                        to clients. The `Access-Control-Expose-Headers` response header can only
+                                        use `*` wildcard as value when the request is not credentialed.
+
+                                        When the `exposeHeaders` config field contains the "*" wildcard and
+                                        the request is credentialed, the gateway cannot use the `*` wildcard in
+                                        the `Access-Control-Expose-Headers` response header.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          HTTPHeaderName is the name of an HTTP header.
+
+                                          Valid values include:
+
+                                          * "Authorization"
+                                          * "Set-Cookie"
+
+                                          Invalid values include:
+
+                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                              headers are not currently supported by this type.
+                                            - "/invalid" - "/ " is an invalid character
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    maxAge:
+                                      default: 5
+                                      description: |-
+                                        MaxAge indicates the duration (in seconds) for the client to cache the
+                                        results of a "preflight" request.
+
+                                        The information provided by the `Access-Control-Allow-Methods` and
+                                        `Access-Control-Allow-Headers` response headers can be cached by the
+                                        client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                        The default value of `Access-Control-Max-Age` response header is 5
+                                        (seconds).
+
+                                        When the `MaxAge` field is unspecified, the gateway sets the response
+                                        header "Access-Control-Max-Age: 5" by default.
+                                      format: int32
+                                      minimum: 1
+                                      type: integer
+                                  type: object
                                 extensionRef:
                                   description: |-
                                     ExtensionRef is an optional, implementation-specific extension to the
@@ -5131,7 +8075,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -5206,7 +8150,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -5234,7 +8178,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
@@ -5244,7 +8188,6 @@ spec:
                                     backends.
 
                                     Support: Extended
-
                                   properties:
                                     backendRef:
                                       description: |-
@@ -5339,9 +8282,49 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |-
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |-
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
                                   required:
                                   - backendRef
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
                                 requestRedirect:
                                   description: |-
                                     RequestRedirect defines a schema for a filter that responds to the
@@ -5493,6 +8476,9 @@ spec:
                                       enum:
                                       - 301
                                       - 302
+                                      - 303
+                                      - 307
+                                      - 308
                                       type: integer
                                   type: object
                                 responseHeaderModifier:
@@ -5528,7 +8514,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -5603,7 +8589,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -5671,6 +8657,7 @@ spec:
                                   - RequestRedirect
                                   - URLRewrite
                                   - ExtensionRef
+                                  - CORS
                                   type: string
                                 urlRewrite:
                                   description: |-
@@ -5760,6 +8747,11 @@ spec:
                               - type
                               type: object
                               x-kubernetes-validations:
+                              - message: filter.cors must be nil if the filter.type
+                                  is not CORS
+                                rule: '!(has(self.cors) && self.type != ''CORS'')'
+                              - message: filter.cors must be specified for CORS filter.type
+                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
                               - message: filter.requestHeaderModifier must be nil
                                   if the filter.type is not RequestHeaderModifier
                                 rule: '!(has(self.requestHeaderModifier) && self.type
@@ -5805,15 +8797,14 @@ spec:
                                 rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
                             maxItems: 16
                             type: array
+                            x-kubernetes-list-type: atomic
                             x-kubernetes-validations:
                             - message: May specify either httpRouteFilterRequestRedirect
                                 or httpRouteFilterRequestRewrite, but not both
                               rule: '!(self.exists(f, f.type == ''RequestRedirect'')
                                 && self.exists(f, f.type == ''URLRewrite''))'
-                            - message: May specify either httpRouteFilterRequestRedirect
-                                or httpRouteFilterRequestRewrite, but not both
-                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: CORS filter cannot be repeated
+                              rule: self.filter(f, f.type == 'CORS').size() <= 1
                             - message: RequestHeaderModifier filter cannot be repeated
                               rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
                                 <= 1
@@ -5915,6 +8906,7 @@ spec:
                             ? has(self.port) : true'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                     filters:
                       description: |-
                         Filters define the filters that are applied to requests that match
@@ -5924,7 +8916,7 @@ spec:
                         they are specified.
 
                         Implementations MAY choose to implement this ordering strictly, rejecting
-                        any combination or order of filters that can not be supported. If implementations
+                        any combination or order of filters that cannot be supported. If implementations
                         choose a strict interpretation of filter ordering, they MUST clearly document
                         that behavior.
 
@@ -5946,7 +8938,7 @@ spec:
 
                         All filters are expected to be compatible with each other except for the
                         URLRewrite and RequestRedirect filters, which may not be combined. If an
-                        implementation can not support other combinations of filters, they must clearly
+                        implementation cannot support other combinations of filters, they must clearly
                         document that limitation. In cases where incompatible or unsupported
                         filters are specified and cause the `Accepted` condition to be set to status
                         `False`, implementations may use the `IncompatibleFilters` reason to specify
@@ -5962,6 +8954,316 @@ spec:
                           authentication strategies, rate-limiting, and traffic shaping. API
                           guarantee/conformance is defined based on the type of the filter.
                         properties:
+                          cors:
+                            description: |-
+                              CORS defines a schema for a filter that responds to the
+                              cross-origin request based on HTTP response header.
+
+                              Support: Extended
+                            properties:
+                              allowCredentials:
+                                description: |-
+                                  AllowCredentials indicates whether the actual cross-origin request allows
+                                  to include credentials.
+
+                                  When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                  response header with value true (case-sensitive).
+
+                                  When set to false or omitted the gateway will omit the header
+                                  `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                  behavior).
+
+                                  Support: Extended
+                                type: boolean
+                              allowHeaders:
+                                description: |-
+                                  AllowHeaders indicates which HTTP request headers are supported for
+                                  accessing the requested resource.
+
+                                  Header names are not case-sensitive.
+
+                                  Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                  response header are separated by a comma (",").
+
+                                  When the `AllowHeaders` field is configured with one or more headers, the
+                                  gateway must return the `Access-Control-Allow-Headers` response header
+                                  which value is present in the `AllowHeaders` field.
+
+                                  If any header name in the `Access-Control-Request-Headers` request header
+                                  is not included in the list of header names specified by the response
+                                  header `Access-Control-Allow-Headers`, it will present an error on the
+                                  client side.
+
+                                  If any header name in the `Access-Control-Allow-Headers` response header
+                                  does not recognize by the client, it will also occur an error on the
+                                  client side.
+
+                                  A wildcard indicates that the requests with all HTTP headers are allowed.
+                                  If config contains the wildcard "*" in allowHeaders and the request is
+                                  not credentialed, the `Access-Control-Allow-Headers` response header
+                                  can either use the `*` wildcard or the value of
+                                  Access-Control-Request-Headers from the request.
+
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Headers` response header. When
+                                  also the `AllowCredentials` field is true and `AllowHeaders` field
+                                  is specified with the `*` wildcard, the gateway must specify one or more
+                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                  header. The value of the header `Access-Control-Allow-Headers` is same as
+                                  the `Access-Control-Request-Headers` header provided by the client. If
+                                  the header `Access-Control-Request-Headers` is not included in the
+                                  request, the gateway will omit the `Access-Control-Allow-Headers`
+                                  response header, instead of specifying the `*` wildcard.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPHeaderName is the name of an HTTP header.
+
+                                    Valid values include:
+
+                                    * "Authorization"
+                                    * "Set-Cookie"
+
+                                    Invalid values include:
+
+                                      - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                        headers are not currently supported by this type.
+                                      - "/invalid" - "/ " is an invalid character
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowHeaders cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowMethods:
+                                description: |-
+                                  AllowMethods indicates which HTTP methods are supported for accessing the
+                                  requested resource.
+
+                                  Valid values are any method defined by RFC9110, along with the special
+                                  value `*`, which represents all HTTP methods are allowed.
+
+                                  Method names are case-sensitive, so these values are also case-sensitive.
+                                  (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                  Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                  response header are separated by a comma (",").
+
+                                  A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                  CORS-safelisted methods are always allowed, regardless of whether they
+                                  are specified in the `AllowMethods` field.
+
+                                  When the `AllowMethods` field is configured with one or more methods, the
+                                  gateway must return the `Access-Control-Allow-Methods` response header
+                                  which value is present in the `AllowMethods` field.
+
+                                  If the HTTP method of the `Access-Control-Request-Method` request header
+                                  is not included in the list of methods specified by the response header
+                                  `Access-Control-Allow-Methods`, it will present an error on the client
+                                  side.
+
+                                  If config contains the wildcard "*" in allowMethods and the request is
+                                  not credentialed, the `Access-Control-Allow-Methods` response header
+                                  can either use the `*` wildcard or the value of
+                                  Access-Control-Request-Method from the request.
+
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Methods` response header. When
+                                  also the `AllowCredentials` field is true and `AllowMethods` field
+                                  specified with the `*` wildcard, the gateway must specify one HTTP method
+                                  in the value of the Access-Control-Allow-Methods response header. The
+                                  value of the header `Access-Control-Allow-Methods` is same as the
+                                  `Access-Control-Request-Method` header provided by the client. If the
+                                  header `Access-Control-Request-Method` is not included in the request,
+                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                  instead of specifying the `*` wildcard.
+
+                                  Support: Extended
+                                items:
+                                  enum:
+                                  - GET
+                                  - HEAD
+                                  - POST
+                                  - PUT
+                                  - DELETE
+                                  - CONNECT
+                                  - OPTIONS
+                                  - TRACE
+                                  - PATCH
+                                  - '*'
+                                  type: string
+                                maxItems: 9
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowMethods cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowOrigins:
+                                description: |-
+                                  AllowOrigins indicates whether the response can be shared with requested
+                                  resource from the given `Origin`.
+
+                                  The `Origin` consists of a scheme and a host, with an optional port, and
+                                  takes the form `<scheme>://<host>(:<port>)`.
+
+                                  Valid values for scheme are: `http` and `https`.
+
+                                  Valid values for port are any integer between 1 and 65535 (the list of
+                                  available TCP/UDP ports). Note that, if not included, port `80` is
+                                  assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                  origins. This may affect origin matching.
+
+                                  The host part of the origin may contain the wildcard character `*`. These
+                                  wildcard characters behave as follows:
+
+                                  * `*` is a greedy match to the _left_, including any number of
+                                    DNS labels to the left of its position. This also means that
+                                    `*` will include any number of period `.` characters to the
+                                    left of its position.
+                                  * A wildcard by itself matches all hosts.
+
+                                  An origin value that includes _only_ the `*` character indicates requests
+                                  from all `Origin`s are allowed.
+
+                                  When the `AllowOrigins` field is configured with multiple origins, it
+                                  means the server supports clients from multiple origins. If the request
+                                  `Origin` matches the configured allowed origins, the gateway must return
+                                  the given `Origin` and sets value of the header
+                                  `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                  client.
+
+                                  The status code of a successful response to a "preflight" request is
+                                  always an OK status (i.e., 204 or 200).
+
+                                  If the request `Origin` does not match the configured allowed origins,
+                                  the gateway returns 204/200 response but doesn't set the relevant
+                                  cross-origin response headers. Alternatively, the gateway responds with
+                                  403 status to the "preflight" request is denied, coupled with omitting
+                                  the CORS headers. The cross-origin request fails on the client side.
+                                  Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                  Conversely, if the request `Origin` matches one of the configured
+                                  allowed origins, the gateway sets the response header
+                                  `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                  header provided by the client.
+
+                                  When config has the wildcard ("*") in allowOrigins, and the request
+                                  is not credentialed (e.g., it is a preflight request), the
+                                  `Access-Control-Allow-Origin` response header either contains the
+                                  wildcard as well or the Origin from the request.
+
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Origin` response header. When
+                                  also the `AllowCredentials` field is true and `AllowOrigins` field
+                                  specified with the `*` wildcard, the gateway must return a single origin
+                                  in the value of the `Access-Control-Allow-Origin` response header,
+                                  instead of specifying the `*` wildcard. The value of the header
+                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                  the client.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                    encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                    scheme ("http" or "https") and a scheme-specific-part, or it should be a single '*' character.
+                                    URIs that include an authority MUST include a fully qualified domain name or
+                                    IP address as the host.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowOrigins cannot contain '*' alongside
+                                    other origins
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              exposeHeaders:
+                                description: |-
+                                  ExposeHeaders indicates which HTTP response headers can be exposed
+                                  to client-side scripts in response to a cross-origin request.
+
+                                  A CORS-safelisted response header is an HTTP header in a CORS response
+                                  that it is considered safe to expose to the client scripts.
+                                  The CORS-safelisted response headers include the following headers:
+                                  `Cache-Control`
+                                  `Content-Language`
+                                  `Content-Length`
+                                  `Content-Type`
+                                  `Expires`
+                                  `Last-Modified`
+                                  `Pragma`
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                  The CORS-safelisted response headers are exposed to client by default.
+
+                                  When an HTTP header name is specified using the `ExposeHeaders` field,
+                                  this additional header will be exposed as part of the response to the
+                                  client.
+
+                                  Header names are not case-sensitive.
+
+                                  Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                  response header are separated by a comma (",").
+
+                                  A wildcard indicates that the responses with all HTTP headers are exposed
+                                  to clients. The `Access-Control-Expose-Headers` response header can only
+                                  use `*` wildcard as value when the request is not credentialed.
+
+                                  When the `exposeHeaders` config field contains the "*" wildcard and
+                                  the request is credentialed, the gateway cannot use the `*` wildcard in
+                                  the `Access-Control-Expose-Headers` response header.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPHeaderName is the name of an HTTP header.
+
+                                    Valid values include:
+
+                                    * "Authorization"
+                                    * "Set-Cookie"
+
+                                    Invalid values include:
+
+                                      - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                        headers are not currently supported by this type.
+                                      - "/invalid" - "/ " is an invalid character
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              maxAge:
+                                default: 5
+                                description: |-
+                                  MaxAge indicates the duration (in seconds) for the client to cache the
+                                  results of a "preflight" request.
+
+                                  The information provided by the `Access-Control-Allow-Methods` and
+                                  `Access-Control-Allow-Headers` response headers can be cached by the
+                                  client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                  The default value of `Access-Control-Max-Age` response header is 5
+                                  (seconds).
+
+                                  When the `MaxAge` field is unspecified, the gateway sets the response
+                                  header "Access-Control-Max-Age: 5" by default.
+                                format: int32
+                                minimum: 1
+                                type: integer
+                            type: object
                           extensionRef:
                             description: |-
                               ExtensionRef is an optional, implementation-specific extension to the
@@ -6029,7 +9331,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -6103,7 +9405,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -6131,7 +9433,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
@@ -6141,7 +9443,6 @@ spec:
                               backends.
 
                               Support: Extended
-
                             properties:
                               backendRef:
                                 description: |-
@@ -6236,9 +9537,49 @@ spec:
                                 - message: Must have port for Service reference
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
+                              fraction:
+                                description: |-
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |-
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
                             required:
                             - backendRef
                             type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
                           requestRedirect:
                             description: |-
                               RequestRedirect defines a schema for a filter that responds to the
@@ -6390,6 +9731,9 @@ spec:
                                 enum:
                                 - 301
                                 - 302
+                                - 303
+                                - 307
+                                - 308
                                 type: integer
                             type: object
                           responseHeaderModifier:
@@ -6424,7 +9768,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -6498,7 +9842,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -6566,6 +9910,7 @@ spec:
                             - RequestRedirect
                             - URLRewrite
                             - ExtensionRef
+                            - CORS
                             type: string
                           urlRewrite:
                             description: |-
@@ -6655,6 +10000,11 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
+                        - message: filter.cors must be nil if the filter.type is not
+                            CORS
+                          rule: '!(has(self.cors) && self.type != ''CORS'')'
+                        - message: filter.cors must be specified for CORS filter.type
+                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
                         - message: filter.requestHeaderModifier must be nil if the
                             filter.type is not RequestHeaderModifier
                           rule: '!(has(self.requestHeaderModifier) && self.type !=
@@ -6697,11 +10047,14 @@ spec:
                           rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                       x-kubernetes-validations:
                       - message: May specify either httpRouteFilterRequestRedirect
                           or httpRouteFilterRequestRewrite, but not both
                         rule: '!(self.exists(f, f.type == ''RequestRedirect'') &&
                           self.exists(f, f.type == ''URLRewrite''))'
+                      - message: CORS filter cannot be repeated
+                        rule: self.filter(f, f.type == 'CORS').size() <= 1
                       - message: RequestHeaderModifier filter cannot be repeated
                         rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
                           <= 1
@@ -6798,7 +10151,7 @@ spec:
                                 name:
                                   description: |-
                                     Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                     If multiple entries specify equivalent header names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
@@ -7008,6 +10361,16 @@ spec:
                         type: object
                       maxItems: 64
                       type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
                     timeouts:
                       description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -7112,7 +10475,9 @@ spec:
                       != 1 || !has(self.matches[0].path) || self.matches[0].path.type
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
+                minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: While 16 rules and 64 matches per rule are allowed, the
                     total number of matches across all rules in a route must be less
@@ -7171,9 +10536,9 @@ spec:
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
 
-                        * The Route refers to a non-existent parent.
+                        * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -7305,8 +10670,6 @@ spec:
                             Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                             generic way to enable any other kind of cross-namespace reference.
 
-
-
                             Support: Core
                           maxLength: 63
                           minLength: 1
@@ -7324,8 +10687,6 @@ spec:
                             as opposed to a listener(s) whose port(s) may be changed. When both Port
                             and SectionName are specified, the name and port of the selected listener
                             must match both specified values.
-
-
 
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
@@ -7378,11 +10739,13 @@ spec:
                       - name
                       type: object
                   required:
+                  - conditions
                   - controllerName
                   - parentRef
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - parents
             type: object
@@ -7506,8 +10869,9 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -7558,12 +10922,6 @@ spec:
                   allowed by something in the namespace they are referring to. For example,
                   Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                   generic way to enable other kinds of cross-namespace reference.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -7625,8 +10983,6 @@ spec:
                         Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
 
-
-
                         Support: Core
                       maxLength: 63
                       minLength: 1
@@ -7644,8 +11000,6 @@ spec:
                         as opposed to a listener(s) whose port(s) may be changed. When both Port
                         and SectionName are specified, the name and port of the selected listener
                         must match both specified values.
-
-
 
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
@@ -7699,6 +11053,7 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName must be specified when parentRefs includes
                     2 or more references to the same parent
@@ -7725,9 +11080,7 @@ spec:
                   - path:
                       type: PathPrefix
                       value: /
-                description: |+
-                  Rules are a list of HTTP matchers, filters and actions.
-
+                description: Rules are a list of HTTP matchers, filters and actions.
                 items:
                   description: |-
                     HTTPRouteRule defines semantics for matching an HTTP request based on
@@ -7779,24 +11132,6 @@ spec:
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
-
-                          <gateway:experimental:description>
-
-                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
-                          honor the appProtocol field if it is set for the target Service Port.
-
-                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
-                          Standard Application Protocols defined in KEP-3726.
-
-                          If a Service appProtocol isn't specified, an implementation MAY infer the
-                          backend protocol through its own means. Implementations MAY infer the
-                          protocol from the Route type referring to the backend Service.
-
-                          If a Route is not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations MUST set the
-                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
@@ -7814,6 +11149,316 @@ spec:
                                 authentication strategies, rate-limiting, and traffic shaping. API
                                 guarantee/conformance is defined based on the type of the filter.
                               properties:
+                                cors:
+                                  description: |-
+                                    CORS defines a schema for a filter that responds to the
+                                    cross-origin request based on HTTP response header.
+
+                                    Support: Extended
+                                  properties:
+                                    allowCredentials:
+                                      description: |-
+                                        AllowCredentials indicates whether the actual cross-origin request allows
+                                        to include credentials.
+
+                                        When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                        response header with value true (case-sensitive).
+
+                                        When set to false or omitted the gateway will omit the header
+                                        `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                        behavior).
+
+                                        Support: Extended
+                                      type: boolean
+                                    allowHeaders:
+                                      description: |-
+                                        AllowHeaders indicates which HTTP request headers are supported for
+                                        accessing the requested resource.
+
+                                        Header names are not case-sensitive.
+
+                                        Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                        response header are separated by a comma (",").
+
+                                        When the `AllowHeaders` field is configured with one or more headers, the
+                                        gateway must return the `Access-Control-Allow-Headers` response header
+                                        which value is present in the `AllowHeaders` field.
+
+                                        If any header name in the `Access-Control-Request-Headers` request header
+                                        is not included in the list of header names specified by the response
+                                        header `Access-Control-Allow-Headers`, it will present an error on the
+                                        client side.
+
+                                        If any header name in the `Access-Control-Allow-Headers` response header
+                                        does not recognize by the client, it will also occur an error on the
+                                        client side.
+
+                                        A wildcard indicates that the requests with all HTTP headers are allowed.
+                                        If config contains the wildcard "*" in allowHeaders and the request is
+                                        not credentialed, the `Access-Control-Allow-Headers` response header
+                                        can either use the `*` wildcard or the value of
+                                        Access-Control-Request-Headers from the request.
+
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Headers` response header. When
+                                        also the `AllowCredentials` field is true and `AllowHeaders` field
+                                        is specified with the `*` wildcard, the gateway must specify one or more
+                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                        header. The value of the header `Access-Control-Allow-Headers` is same as
+                                        the `Access-Control-Request-Headers` header provided by the client. If
+                                        the header `Access-Control-Request-Headers` is not included in the
+                                        request, the gateway will omit the `Access-Control-Allow-Headers`
+                                        response header, instead of specifying the `*` wildcard.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          HTTPHeaderName is the name of an HTTP header.
+
+                                          Valid values include:
+
+                                          * "Authorization"
+                                          * "Set-Cookie"
+
+                                          Invalid values include:
+
+                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                              headers are not currently supported by this type.
+                                            - "/invalid" - "/ " is an invalid character
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowHeaders cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowMethods:
+                                      description: |-
+                                        AllowMethods indicates which HTTP methods are supported for accessing the
+                                        requested resource.
+
+                                        Valid values are any method defined by RFC9110, along with the special
+                                        value `*`, which represents all HTTP methods are allowed.
+
+                                        Method names are case-sensitive, so these values are also case-sensitive.
+                                        (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                        Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                        response header are separated by a comma (",").
+
+                                        A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                        CORS-safelisted methods are always allowed, regardless of whether they
+                                        are specified in the `AllowMethods` field.
+
+                                        When the `AllowMethods` field is configured with one or more methods, the
+                                        gateway must return the `Access-Control-Allow-Methods` response header
+                                        which value is present in the `AllowMethods` field.
+
+                                        If the HTTP method of the `Access-Control-Request-Method` request header
+                                        is not included in the list of methods specified by the response header
+                                        `Access-Control-Allow-Methods`, it will present an error on the client
+                                        side.
+
+                                        If config contains the wildcard "*" in allowMethods and the request is
+                                        not credentialed, the `Access-Control-Allow-Methods` response header
+                                        can either use the `*` wildcard or the value of
+                                        Access-Control-Request-Method from the request.
+
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Methods` response header. When
+                                        also the `AllowCredentials` field is true and `AllowMethods` field
+                                        specified with the `*` wildcard, the gateway must specify one HTTP method
+                                        in the value of the Access-Control-Allow-Methods response header. The
+                                        value of the header `Access-Control-Allow-Methods` is same as the
+                                        `Access-Control-Request-Method` header provided by the client. If the
+                                        header `Access-Control-Request-Method` is not included in the request,
+                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                        instead of specifying the `*` wildcard.
+
+                                        Support: Extended
+                                      items:
+                                        enum:
+                                        - GET
+                                        - HEAD
+                                        - POST
+                                        - PUT
+                                        - DELETE
+                                        - CONNECT
+                                        - OPTIONS
+                                        - TRACE
+                                        - PATCH
+                                        - '*'
+                                        type: string
+                                      maxItems: 9
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowMethods cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowOrigins:
+                                      description: |-
+                                        AllowOrigins indicates whether the response can be shared with requested
+                                        resource from the given `Origin`.
+
+                                        The `Origin` consists of a scheme and a host, with an optional port, and
+                                        takes the form `<scheme>://<host>(:<port>)`.
+
+                                        Valid values for scheme are: `http` and `https`.
+
+                                        Valid values for port are any integer between 1 and 65535 (the list of
+                                        available TCP/UDP ports). Note that, if not included, port `80` is
+                                        assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                        origins. This may affect origin matching.
+
+                                        The host part of the origin may contain the wildcard character `*`. These
+                                        wildcard characters behave as follows:
+
+                                        * `*` is a greedy match to the _left_, including any number of
+                                          DNS labels to the left of its position. This also means that
+                                          `*` will include any number of period `.` characters to the
+                                          left of its position.
+                                        * A wildcard by itself matches all hosts.
+
+                                        An origin value that includes _only_ the `*` character indicates requests
+                                        from all `Origin`s are allowed.
+
+                                        When the `AllowOrigins` field is configured with multiple origins, it
+                                        means the server supports clients from multiple origins. If the request
+                                        `Origin` matches the configured allowed origins, the gateway must return
+                                        the given `Origin` and sets value of the header
+                                        `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                        client.
+
+                                        The status code of a successful response to a "preflight" request is
+                                        always an OK status (i.e., 204 or 200).
+
+                                        If the request `Origin` does not match the configured allowed origins,
+                                        the gateway returns 204/200 response but doesn't set the relevant
+                                        cross-origin response headers. Alternatively, the gateway responds with
+                                        403 status to the "preflight" request is denied, coupled with omitting
+                                        the CORS headers. The cross-origin request fails on the client side.
+                                        Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                        Conversely, if the request `Origin` matches one of the configured
+                                        allowed origins, the gateway sets the response header
+                                        `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                        header provided by the client.
+
+                                        When config has the wildcard ("*") in allowOrigins, and the request
+                                        is not credentialed (e.g., it is a preflight request), the
+                                        `Access-Control-Allow-Origin` response header either contains the
+                                        wildcard as well or the Origin from the request.
+
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Origin` response header. When
+                                        also the `AllowCredentials` field is true and `AllowOrigins` field
+                                        specified with the `*` wildcard, the gateway must return a single origin
+                                        in the value of the `Access-Control-Allow-Origin` response header,
+                                        instead of specifying the `*` wildcard. The value of the header
+                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                        the client.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                          encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                          scheme ("http" or "https") and a scheme-specific-part, or it should be a single '*' character.
+                                          URIs that include an authority MUST include a fully qualified domain name or
+                                          IP address as the host.
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowOrigins cannot contain '*' alongside
+                                          other origins
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    exposeHeaders:
+                                      description: |-
+                                        ExposeHeaders indicates which HTTP response headers can be exposed
+                                        to client-side scripts in response to a cross-origin request.
+
+                                        A CORS-safelisted response header is an HTTP header in a CORS response
+                                        that it is considered safe to expose to the client scripts.
+                                        The CORS-safelisted response headers include the following headers:
+                                        `Cache-Control`
+                                        `Content-Language`
+                                        `Content-Length`
+                                        `Content-Type`
+                                        `Expires`
+                                        `Last-Modified`
+                                        `Pragma`
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                        The CORS-safelisted response headers are exposed to client by default.
+
+                                        When an HTTP header name is specified using the `ExposeHeaders` field,
+                                        this additional header will be exposed as part of the response to the
+                                        client.
+
+                                        Header names are not case-sensitive.
+
+                                        Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                        response header are separated by a comma (",").
+
+                                        A wildcard indicates that the responses with all HTTP headers are exposed
+                                        to clients. The `Access-Control-Expose-Headers` response header can only
+                                        use `*` wildcard as value when the request is not credentialed.
+
+                                        When the `exposeHeaders` config field contains the "*" wildcard and
+                                        the request is credentialed, the gateway cannot use the `*` wildcard in
+                                        the `Access-Control-Expose-Headers` response header.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          HTTPHeaderName is the name of an HTTP header.
+
+                                          Valid values include:
+
+                                          * "Authorization"
+                                          * "Set-Cookie"
+
+                                          Invalid values include:
+
+                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                              headers are not currently supported by this type.
+                                            - "/invalid" - "/ " is an invalid character
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    maxAge:
+                                      default: 5
+                                      description: |-
+                                        MaxAge indicates the duration (in seconds) for the client to cache the
+                                        results of a "preflight" request.
+
+                                        The information provided by the `Access-Control-Allow-Methods` and
+                                        `Access-Control-Allow-Headers` response headers can be cached by the
+                                        client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                        The default value of `Access-Control-Max-Age` response header is 5
+                                        (seconds).
+
+                                        When the `MaxAge` field is unspecified, the gateway sets the response
+                                        header "Access-Control-Max-Age: 5" by default.
+                                      format: int32
+                                      minimum: 1
+                                      type: integer
+                                  type: object
                                 extensionRef:
                                   description: |-
                                     ExtensionRef is an optional, implementation-specific extension to the
@@ -7882,7 +11527,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -7957,7 +11602,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -7985,7 +11630,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
@@ -7995,7 +11640,6 @@ spec:
                                     backends.
 
                                     Support: Extended
-
                                   properties:
                                     backendRef:
                                       description: |-
@@ -8090,9 +11734,49 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |-
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |-
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
                                   required:
                                   - backendRef
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
                                 requestRedirect:
                                   description: |-
                                     RequestRedirect defines a schema for a filter that responds to the
@@ -8244,6 +11928,9 @@ spec:
                                       enum:
                                       - 301
                                       - 302
+                                      - 303
+                                      - 307
+                                      - 308
                                       type: integer
                                   type: object
                                 responseHeaderModifier:
@@ -8279,7 +11966,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -8354,7 +12041,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -8422,6 +12109,7 @@ spec:
                                   - RequestRedirect
                                   - URLRewrite
                                   - ExtensionRef
+                                  - CORS
                                   type: string
                                 urlRewrite:
                                   description: |-
@@ -8511,6 +12199,11 @@ spec:
                               - type
                               type: object
                               x-kubernetes-validations:
+                              - message: filter.cors must be nil if the filter.type
+                                  is not CORS
+                                rule: '!(has(self.cors) && self.type != ''CORS'')'
+                              - message: filter.cors must be specified for CORS filter.type
+                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
                               - message: filter.requestHeaderModifier must be nil
                                   if the filter.type is not RequestHeaderModifier
                                 rule: '!(has(self.requestHeaderModifier) && self.type
@@ -8556,15 +12249,14 @@ spec:
                                 rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
                             maxItems: 16
                             type: array
+                            x-kubernetes-list-type: atomic
                             x-kubernetes-validations:
                             - message: May specify either httpRouteFilterRequestRedirect
                                 or httpRouteFilterRequestRewrite, but not both
                               rule: '!(self.exists(f, f.type == ''RequestRedirect'')
                                 && self.exists(f, f.type == ''URLRewrite''))'
-                            - message: May specify either httpRouteFilterRequestRedirect
-                                or httpRouteFilterRequestRewrite, but not both
-                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: CORS filter cannot be repeated
+                              rule: self.filter(f, f.type == 'CORS').size() <= 1
                             - message: RequestHeaderModifier filter cannot be repeated
                               rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
                                 <= 1
@@ -8666,6 +12358,7 @@ spec:
                             ? has(self.port) : true'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                     filters:
                       description: |-
                         Filters define the filters that are applied to requests that match
@@ -8675,7 +12368,7 @@ spec:
                         they are specified.
 
                         Implementations MAY choose to implement this ordering strictly, rejecting
-                        any combination or order of filters that can not be supported. If implementations
+                        any combination or order of filters that cannot be supported. If implementations
                         choose a strict interpretation of filter ordering, they MUST clearly document
                         that behavior.
 
@@ -8697,7 +12390,7 @@ spec:
 
                         All filters are expected to be compatible with each other except for the
                         URLRewrite and RequestRedirect filters, which may not be combined. If an
-                        implementation can not support other combinations of filters, they must clearly
+                        implementation cannot support other combinations of filters, they must clearly
                         document that limitation. In cases where incompatible or unsupported
                         filters are specified and cause the `Accepted` condition to be set to status
                         `False`, implementations may use the `IncompatibleFilters` reason to specify
@@ -8713,6 +12406,316 @@ spec:
                           authentication strategies, rate-limiting, and traffic shaping. API
                           guarantee/conformance is defined based on the type of the filter.
                         properties:
+                          cors:
+                            description: |-
+                              CORS defines a schema for a filter that responds to the
+                              cross-origin request based on HTTP response header.
+
+                              Support: Extended
+                            properties:
+                              allowCredentials:
+                                description: |-
+                                  AllowCredentials indicates whether the actual cross-origin request allows
+                                  to include credentials.
+
+                                  When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                  response header with value true (case-sensitive).
+
+                                  When set to false or omitted the gateway will omit the header
+                                  `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                  behavior).
+
+                                  Support: Extended
+                                type: boolean
+                              allowHeaders:
+                                description: |-
+                                  AllowHeaders indicates which HTTP request headers are supported for
+                                  accessing the requested resource.
+
+                                  Header names are not case-sensitive.
+
+                                  Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                  response header are separated by a comma (",").
+
+                                  When the `AllowHeaders` field is configured with one or more headers, the
+                                  gateway must return the `Access-Control-Allow-Headers` response header
+                                  which value is present in the `AllowHeaders` field.
+
+                                  If any header name in the `Access-Control-Request-Headers` request header
+                                  is not included in the list of header names specified by the response
+                                  header `Access-Control-Allow-Headers`, it will present an error on the
+                                  client side.
+
+                                  If any header name in the `Access-Control-Allow-Headers` response header
+                                  does not recognize by the client, it will also occur an error on the
+                                  client side.
+
+                                  A wildcard indicates that the requests with all HTTP headers are allowed.
+                                  If config contains the wildcard "*" in allowHeaders and the request is
+                                  not credentialed, the `Access-Control-Allow-Headers` response header
+                                  can either use the `*` wildcard or the value of
+                                  Access-Control-Request-Headers from the request.
+
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Headers` response header. When
+                                  also the `AllowCredentials` field is true and `AllowHeaders` field
+                                  is specified with the `*` wildcard, the gateway must specify one or more
+                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                  header. The value of the header `Access-Control-Allow-Headers` is same as
+                                  the `Access-Control-Request-Headers` header provided by the client. If
+                                  the header `Access-Control-Request-Headers` is not included in the
+                                  request, the gateway will omit the `Access-Control-Allow-Headers`
+                                  response header, instead of specifying the `*` wildcard.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPHeaderName is the name of an HTTP header.
+
+                                    Valid values include:
+
+                                    * "Authorization"
+                                    * "Set-Cookie"
+
+                                    Invalid values include:
+
+                                      - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                        headers are not currently supported by this type.
+                                      - "/invalid" - "/ " is an invalid character
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowHeaders cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowMethods:
+                                description: |-
+                                  AllowMethods indicates which HTTP methods are supported for accessing the
+                                  requested resource.
+
+                                  Valid values are any method defined by RFC9110, along with the special
+                                  value `*`, which represents all HTTP methods are allowed.
+
+                                  Method names are case-sensitive, so these values are also case-sensitive.
+                                  (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                  Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                  response header are separated by a comma (",").
+
+                                  A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                  CORS-safelisted methods are always allowed, regardless of whether they
+                                  are specified in the `AllowMethods` field.
+
+                                  When the `AllowMethods` field is configured with one or more methods, the
+                                  gateway must return the `Access-Control-Allow-Methods` response header
+                                  which value is present in the `AllowMethods` field.
+
+                                  If the HTTP method of the `Access-Control-Request-Method` request header
+                                  is not included in the list of methods specified by the response header
+                                  `Access-Control-Allow-Methods`, it will present an error on the client
+                                  side.
+
+                                  If config contains the wildcard "*" in allowMethods and the request is
+                                  not credentialed, the `Access-Control-Allow-Methods` response header
+                                  can either use the `*` wildcard or the value of
+                                  Access-Control-Request-Method from the request.
+
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Methods` response header. When
+                                  also the `AllowCredentials` field is true and `AllowMethods` field
+                                  specified with the `*` wildcard, the gateway must specify one HTTP method
+                                  in the value of the Access-Control-Allow-Methods response header. The
+                                  value of the header `Access-Control-Allow-Methods` is same as the
+                                  `Access-Control-Request-Method` header provided by the client. If the
+                                  header `Access-Control-Request-Method` is not included in the request,
+                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                  instead of specifying the `*` wildcard.
+
+                                  Support: Extended
+                                items:
+                                  enum:
+                                  - GET
+                                  - HEAD
+                                  - POST
+                                  - PUT
+                                  - DELETE
+                                  - CONNECT
+                                  - OPTIONS
+                                  - TRACE
+                                  - PATCH
+                                  - '*'
+                                  type: string
+                                maxItems: 9
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowMethods cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowOrigins:
+                                description: |-
+                                  AllowOrigins indicates whether the response can be shared with requested
+                                  resource from the given `Origin`.
+
+                                  The `Origin` consists of a scheme and a host, with an optional port, and
+                                  takes the form `<scheme>://<host>(:<port>)`.
+
+                                  Valid values for scheme are: `http` and `https`.
+
+                                  Valid values for port are any integer between 1 and 65535 (the list of
+                                  available TCP/UDP ports). Note that, if not included, port `80` is
+                                  assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                  origins. This may affect origin matching.
+
+                                  The host part of the origin may contain the wildcard character `*`. These
+                                  wildcard characters behave as follows:
+
+                                  * `*` is a greedy match to the _left_, including any number of
+                                    DNS labels to the left of its position. This also means that
+                                    `*` will include any number of period `.` characters to the
+                                    left of its position.
+                                  * A wildcard by itself matches all hosts.
+
+                                  An origin value that includes _only_ the `*` character indicates requests
+                                  from all `Origin`s are allowed.
+
+                                  When the `AllowOrigins` field is configured with multiple origins, it
+                                  means the server supports clients from multiple origins. If the request
+                                  `Origin` matches the configured allowed origins, the gateway must return
+                                  the given `Origin` and sets value of the header
+                                  `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                  client.
+
+                                  The status code of a successful response to a "preflight" request is
+                                  always an OK status (i.e., 204 or 200).
+
+                                  If the request `Origin` does not match the configured allowed origins,
+                                  the gateway returns 204/200 response but doesn't set the relevant
+                                  cross-origin response headers. Alternatively, the gateway responds with
+                                  403 status to the "preflight" request is denied, coupled with omitting
+                                  the CORS headers. The cross-origin request fails on the client side.
+                                  Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                  Conversely, if the request `Origin` matches one of the configured
+                                  allowed origins, the gateway sets the response header
+                                  `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                  header provided by the client.
+
+                                  When config has the wildcard ("*") in allowOrigins, and the request
+                                  is not credentialed (e.g., it is a preflight request), the
+                                  `Access-Control-Allow-Origin` response header either contains the
+                                  wildcard as well or the Origin from the request.
+
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Origin` response header. When
+                                  also the `AllowCredentials` field is true and `AllowOrigins` field
+                                  specified with the `*` wildcard, the gateway must return a single origin
+                                  in the value of the `Access-Control-Allow-Origin` response header,
+                                  instead of specifying the `*` wildcard. The value of the header
+                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                  the client.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                    encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                    scheme ("http" or "https") and a scheme-specific-part, or it should be a single '*' character.
+                                    URIs that include an authority MUST include a fully qualified domain name or
+                                    IP address as the host.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowOrigins cannot contain '*' alongside
+                                    other origins
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              exposeHeaders:
+                                description: |-
+                                  ExposeHeaders indicates which HTTP response headers can be exposed
+                                  to client-side scripts in response to a cross-origin request.
+
+                                  A CORS-safelisted response header is an HTTP header in a CORS response
+                                  that it is considered safe to expose to the client scripts.
+                                  The CORS-safelisted response headers include the following headers:
+                                  `Cache-Control`
+                                  `Content-Language`
+                                  `Content-Length`
+                                  `Content-Type`
+                                  `Expires`
+                                  `Last-Modified`
+                                  `Pragma`
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                  The CORS-safelisted response headers are exposed to client by default.
+
+                                  When an HTTP header name is specified using the `ExposeHeaders` field,
+                                  this additional header will be exposed as part of the response to the
+                                  client.
+
+                                  Header names are not case-sensitive.
+
+                                  Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                  response header are separated by a comma (",").
+
+                                  A wildcard indicates that the responses with all HTTP headers are exposed
+                                  to clients. The `Access-Control-Expose-Headers` response header can only
+                                  use `*` wildcard as value when the request is not credentialed.
+
+                                  When the `exposeHeaders` config field contains the "*" wildcard and
+                                  the request is credentialed, the gateway cannot use the `*` wildcard in
+                                  the `Access-Control-Expose-Headers` response header.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPHeaderName is the name of an HTTP header.
+
+                                    Valid values include:
+
+                                    * "Authorization"
+                                    * "Set-Cookie"
+
+                                    Invalid values include:
+
+                                      - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                        headers are not currently supported by this type.
+                                      - "/invalid" - "/ " is an invalid character
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              maxAge:
+                                default: 5
+                                description: |-
+                                  MaxAge indicates the duration (in seconds) for the client to cache the
+                                  results of a "preflight" request.
+
+                                  The information provided by the `Access-Control-Allow-Methods` and
+                                  `Access-Control-Allow-Headers` response headers can be cached by the
+                                  client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                  The default value of `Access-Control-Max-Age` response header is 5
+                                  (seconds).
+
+                                  When the `MaxAge` field is unspecified, the gateway sets the response
+                                  header "Access-Control-Max-Age: 5" by default.
+                                format: int32
+                                minimum: 1
+                                type: integer
+                            type: object
                           extensionRef:
                             description: |-
                               ExtensionRef is an optional, implementation-specific extension to the
@@ -8780,7 +12783,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -8854,7 +12857,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -8882,7 +12885,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
@@ -8892,7 +12895,6 @@ spec:
                               backends.
 
                               Support: Extended
-
                             properties:
                               backendRef:
                                 description: |-
@@ -8987,9 +12989,49 @@ spec:
                                 - message: Must have port for Service reference
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
+                              fraction:
+                                description: |-
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |-
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
                             required:
                             - backendRef
                             type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
                           requestRedirect:
                             description: |-
                               RequestRedirect defines a schema for a filter that responds to the
@@ -9141,6 +13183,9 @@ spec:
                                 enum:
                                 - 301
                                 - 302
+                                - 303
+                                - 307
+                                - 308
                                 type: integer
                             type: object
                           responseHeaderModifier:
@@ -9175,7 +13220,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -9249,7 +13294,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -9317,6 +13362,7 @@ spec:
                             - RequestRedirect
                             - URLRewrite
                             - ExtensionRef
+                            - CORS
                             type: string
                           urlRewrite:
                             description: |-
@@ -9406,6 +13452,11 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
+                        - message: filter.cors must be nil if the filter.type is not
+                            CORS
+                          rule: '!(has(self.cors) && self.type != ''CORS'')'
+                        - message: filter.cors must be specified for CORS filter.type
+                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
                         - message: filter.requestHeaderModifier must be nil if the
                             filter.type is not RequestHeaderModifier
                           rule: '!(has(self.requestHeaderModifier) && self.type !=
@@ -9448,11 +13499,14 @@ spec:
                           rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                       x-kubernetes-validations:
                       - message: May specify either httpRouteFilterRequestRedirect
                           or httpRouteFilterRequestRewrite, but not both
                         rule: '!(self.exists(f, f.type == ''RequestRedirect'') &&
                           self.exists(f, f.type == ''URLRewrite''))'
+                      - message: CORS filter cannot be repeated
+                        rule: self.filter(f, f.type == 'CORS').size() <= 1
                       - message: RequestHeaderModifier filter cannot be repeated
                         rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
                           <= 1
@@ -9549,7 +13603,7 @@ spec:
                                 name:
                                   description: |-
                                     Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                     If multiple entries specify equivalent header names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
@@ -9759,6 +13813,16 @@ spec:
                         type: object
                       maxItems: 64
                       type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
                     timeouts:
                       description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -9863,7 +13927,9 @@ spec:
                       != 1 || !has(self.matches[0].path) || self.matches[0].path.type
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
+                minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: While 16 rules and 64 matches per rule are allowed, the
                     total number of matches across all rules in a route must be less
@@ -9922,9 +13988,9 @@ spec:
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
 
-                        * The Route refers to a non-existent parent.
+                        * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -10056,8 +14122,6 @@ spec:
                             Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                             generic way to enable any other kind of cross-namespace reference.
 
-
-
                             Support: Core
                           maxLength: 63
                           minLength: 1
@@ -10075,8 +14139,6 @@ spec:
                             as opposed to a listener(s) whose port(s) may be changed. When both Port
                             and SectionName are specified, the name and port of the selected listener
                             must match both specified values.
-
-
 
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
@@ -10129,11 +14191,13 @@ spec:
                       - name
                       type: object
                   required:
+                  - conditions
                   - controllerName
                   - parentRef
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - parents
             type: object
@@ -10152,16 +14216,799 @@ status:
   storedVersions: null
 ---
 #
+# config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  name: listenersets.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: ListenerSet
+    listKind: ListenerSetList
+    plural: listenersets
+    shortNames:
+    - lset
+    singular: listenerset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ListenerSet defines a set of additional listeners to attach to an existing Gateway.
+          This resource provides a mechanism to merge multiple listeners into a single Gateway.
+
+          The parent Gateway must explicitly allow ListenerSet attachment through its
+          AllowedListeners configuration. By default, Gateways do not allow ListenerSet
+          attachment.
+
+          Routes can attach to a ListenerSet by specifying it as a parentRef, and can
+          optionally target specific listeners using the sectionName field.
+
+          Policy Attachment:
+          - Policies that attach to a ListenerSet apply to all listeners defined in that resource
+          - Policies do not impact listeners in the parent Gateway
+          - Different ListenerSets attached to the same Gateway can have different policies
+          - If an implementation cannot apply a policy to specific listeners, it should reject the policy
+
+          ReferenceGrant Semantics:
+          - ReferenceGrants applied to a Gateway are not inherited by child ListenerSets
+          - ReferenceGrants applied to a ListenerSet do not grant permission to the parent Gateway's listeners
+          - A ListenerSet can reference secrets/backends in its own namespace without a ReferenceGrant
+
+          Gateway Integration:
+            - The parent Gateway's status will include "AttachedListenerSets"
+              which is the count of ListenerSets that have successfully attached to a Gateway
+              A ListenerSet is successfully attached to a Gateway when all the following conditions are met:
+            - The ListenerSet is selected by the Gateway's AllowedListeners field
+            - The ListenerSet has a valid ParentRef selecting the Gateway
+            - The ListenerSet's status has the condition "Accepted: true"
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ListenerSet.
+            properties:
+              listeners:
+                description: |-
+                  Listeners associated with this ListenerSet. Listeners define
+                  logical endpoints that are bound on this referenced parent Gateway's addresses.
+
+                  Listeners in a `Gateway` and their attached `ListenerSets` are concatenated
+                  as a list when programming the underlying infrastructure. Each listener
+                  name does not need to be unique across the Gateway and ListenerSets.
+                  See ListenerEntry.Name for more details.
+
+                  Implementations MUST treat the parent Gateway as having the merged
+                  list of all listeners from itself and attached ListenerSets using
+                  the following precedence:
+
+                  1. "parent" Gateway
+                  2. ListenerSet ordered by creation time (oldest first)
+                  3. ListenerSet ordered alphabetically by "{namespace}/{name}".
+
+                  An implementation MAY reject listeners by setting the ListenerEntryStatus
+                  `Accepted` condition to False with the Reason `TooManyListeners`
+
+                  If a listener has a conflict, this will be reported in the
+                  Status.ListenerEntryStatus setting the `Conflicted` condition to True.
+
+                  Implementations SHOULD be cautious about what information from the
+                  parent or siblings are reported to avoid accidentally leaking
+                  sensitive information that the child would not otherwise have access
+                  to. This can include contents of secrets etc.
+                items:
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: |-
+                        AllowedRoutes defines the types of routes that MAY be attached to a
+                        Listener and the trusted namespaces where those Route resources MAY be
+                        present.
+
+                        Although a client request may match multiple route rules, only one rule
+                        may ultimately receive the request. Matching precedence MUST be
+                        determined in order of the following criteria:
+
+                        * The most specific match as defined by the Route type.
+                        * The oldest Route based on creation timestamp. For example, a Route with
+                          a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                          a Route with a creation timestamp of "2020-09-08 01:02:04".
+                        * If everything else is equivalent, the Route appearing first in
+                          alphabetical order (namespace/name) should be given precedence. For
+                          example, foo/bar is given precedence over foo/baz.
+
+                        All valid rules within a Route attached to this Listener should be
+                        implemented. Invalid Route rules can be ignored (sometimes that will mean
+                        the full Route). If a Route rule transitions from valid to invalid,
+                        support for that Route rule should be dropped to ensure consistency. For
+                        example, even if a filter specified by a Route rule is invalid, the rest
+                        of the rules within that Route should still be supported.
+                      properties:
+                        kinds:
+                          description: |-
+                            Kinds specifies the groups and kinds of Routes that are allowed to bind
+                            to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                            selected are determined using the Listener protocol.
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                            with the application protocol specified in the Listener's Protocol field.
+                            If an implementation does not support or recognize this resource type, it
+                            MUST set the "ResolvedRefs" condition to False for this Listener with the
+                            "InvalidRouteKinds" reason.
+
+                            Support: Core
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        namespaces:
+                          default:
+                            from: Same
+                          description: |-
+                            Namespaces indicates namespaces from which Routes may be attached to this
+                            Listener. This is restricted to the namespace of this Gateway by default.
+
+                            Support: Core
+                          properties:
+                            from:
+                              default: Same
+                              description: |-
+                                From indicates where Routes will be selected for this Gateway. Possible
+                                values are:
+
+                                * All: Routes in all namespaces may be used by this Gateway.
+                                * Selector: Routes in namespaces selected by the selector may be used by
+                                  this Gateway.
+                                * Same: Only Routes in the same namespace may be used by this Gateway.
+
+                                Support: Core
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: |-
+                                Selector must be specified when From is set to "Selector". In that case,
+                                only Routes in Namespaces matching this Selector will be selected by this
+                                Gateway. This field is ignored for other values of "From".
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: |-
+                        Hostname specifies the virtual hostname to match for protocol types that
+                        define this concept. When unspecified, all hostnames are matched. This
+                        field is ignored for protocols that don't require hostname based
+                        matching.
+
+                        Implementations MUST apply Hostname matching appropriately for each of
+                        the following protocols:
+
+                        * TLS: The Listener Hostname MUST match the SNI.
+                        * HTTP: The Listener Hostname MUST match the Host header of the request.
+                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                          protocol layers as described above. If an implementation does not
+                          ensure that both the SNI and Host header match the Listener hostname,
+                          it MUST clearly document that.
+
+                        For HTTPRoute and TLSRoute resources, there is an interaction with the
+                        `spec.hostnames` array. When both listener and route specify hostnames,
+                        there MUST be an intersection between the values for a Route to be
+                        accepted. For more information, refer to the Route specific Hostnames
+                        documentation.
+
+                        Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                        as a suffix match. That means that a match for `*.example.com` would match
+                        both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the Listener. This name MUST be unique within a
+                        ListenerSet.
+
+                        Name is not required to be unique across a Gateway and ListenerSets.
+                        Routes can attach to a Listener by having a ListenerSet as a parentRef
+                        and setting the SectionName
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port. Multiple listeners may use the
+                        same port, subject to the Listener compatibility rules.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: Protocol specifies the network protocol this listener
+                        expects to receive.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: |-
+                        TLS is the TLS configuration for the Listener. This field is required if
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+                        The association of SNIs to Certificate defined in ListenerTLSConfig is
+                        defined based on the Hostname field for this listener.
+
+                        The GatewayClass MUST use the longest matching SNI out of all
+                        available certificates for any TLS handshake.
+                      properties:
+                        certificateRefs:
+                          description: |-
+                            CertificateRefs contains a series of references to Kubernetes objects that
+                            contains TLS certificates and private keys. These certificates are used to
+                            establish a TLS handshake for requests that match the hostname of the
+                            associated listener.
+
+                            A single CertificateRef to a Kubernetes Secret has "Core" support.
+                            Implementations MAY choose to support attaching multiple certificates to
+                            a Listener, but this behavior is implementation-specific.
+
+                            References to a resource in different namespace are invalid UNLESS there
+                            is a ReferenceGrant in the target namespace that allows the certificate
+                            to be attached. If a ReferenceGrant does not allow this reference, the
+                            "ResolvedRefs" condition MUST be set to False for this listener with the
+                            "RefNotPermitted" reason.
+
+                            This field is required to have at least one element when the mode is set
+                            to "Terminate" (default) and is optional otherwise.
+
+                            CertificateRefs can reference to standard Kubernetes resources, i.e.
+                            Secret, or implementation-specific custom resources.
+
+                            Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+                            Support: Implementation-specific (More than one reference or other resource types)
+                          items:
+                            description: |-
+                              SecretObjectReference identifies an API object including its namespace,
+                              defaulting to Secret.
+
+                              The API object must be valid in the cluster; the Group and Kind must
+                              be registered in the cluster for this reference to be valid.
+
+                              References to objects with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate Conditions set
+                              on the containing object.
+                            properties:
+                              group:
+                                default: ""
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of the referenced object. When unspecified, the local
+                                  namespace is inferred.
+
+                                  Note that when a namespace different than the local namespace is specified,
+                                  a ReferenceGrant object is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the ReferenceGrant
+                                  documentation for details.
+
+                                  Support: Core
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        mode:
+                          default: Terminate
+                          description: |-
+                            Mode defines the TLS behavior for the TLS session initiated by the client.
+                            There are two possible modes:
+
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
+                            - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                              implies that the Gateway can't decipher the TLS stream except for
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
+
+                            Support: Core
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: |-
+                              AnnotationValue is the value of an annotation in Gateway API. This is used
+                              for validation of maps such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation in that case is based
+                              on the entire size of the annotations struct.
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: |-
+                            Options are a list of key/value pairs to enable extended TLS
+                            configuration for each implementation. For example, configuring the
+                            minimum TLS version or supported cipher suites.
+
+                            A set of common keys MAY be defined by the API in the future. To avoid
+                            any ambiguity, implementation-specific definitions MUST use
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by Gateway API.
+
+                            Support: Implementation-specific
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: tls mode must be set for protocol TLS
+                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
+                    && l.tls.mode != '''' : true))'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port)
+                    && l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname)
+                    && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname)
+                    && !has(l2.hostname))))'
+              parentRef:
+                description: ParentRef references the Gateway that the listeners are
+                  attached to.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    default: Gateway
+                    description: Kind is kind of the referent. For example "Gateway".
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.  If not present,
+                      the namespace of the referent is assumed to be the same as
+                      the namespace of the referring object.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - listeners
+            - parentRef
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of ListenerSet.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the ListenerSet.
+
+                  Implementations MUST express ListenerSet conditions using the
+                  `ListenerSetConditionType` and `ListenerSetConditionReason`
+                  constants so that operators and tools can converge on a common
+                  vocabulary to describe ListenerSet state.
+
+                  Known condition types are:
+
+                  * "Accepted"
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: |-
+                        AttachedRoutes represents the total number of Routes that have been
+                        successfully attached to this Listener.
+
+                        Successful attachment of a Route to a Listener is based solely on the
+                        combination of the AllowedRoutes field on the corresponding Listener
+                        and the Route's ParentRefs field. A Route is successfully attached to
+                        a Listener when it is selected by the Listener's AllowedRoutes field
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+                        resource or a specific Listener as a parent resource (more detail on
+                        attachment semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener status does not impact
+                        successful attachment, i.e. the AttachedRoutes field count MUST be set
+                        for Listeners, even if the Accepted condition of an individual Listener is set
+                        to "False". The AttachedRoutes number represents the number of Routes with
+                        the Accepted condition set to "True" that have been attached to this Listener.
+                        Routes with any other value for the Accepted condition MUST NOT be included
+                        in this count.
+
+                        Uses for this field include troubleshooting Route attachment and
+                        measuring blast radius/impact of changes to a Listener.
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: |-
+                        SupportedKinds is the list indicating the Kinds supported by this
+                        listener. This MUST represent the kinds supported by an implementation for
+                        that Listener configuration.
+
+                        If kinds are specified in Spec that are not supported, they MUST NOT
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+                        condition to "False" with the "InvalidRouteKinds" reason. If both valid
+                        and invalid Route kinds are specified, the implementation MUST
+                        reference the valid Route kinds that have been specified.
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
 # config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
-  creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -10176,6 +15023,169 @@ spec:
     singular: referencegrant
   scope: Namespaced
   versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ReferenceGrant identifies kinds of resources in other namespaces that are
+          trusted to reference the specified kinds of resources in the same namespace
+          as the policy.
+
+          Each ReferenceGrant can be used to represent a unique trust relationship.
+          Additional Reference Grants can be used to add to the set of trusted
+          sources of inbound references for the namespace they are defined within.
+
+          All cross-namespace references in Gateway API (with the exception of cross-namespace
+          Gateway-route attachment) require a ReferenceGrant.
+
+          ReferenceGrant is a form of runtime verification allowing users to assert
+          which cross-namespace object references are permitted. Implementations that
+          support ReferenceGrant MUST NOT permit cross-namespace references which have
+          no grant, and MUST respond to the removal of a grant by revoking the access
+          that the grant allowed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ReferenceGrant.
+            properties:
+              from:
+                description: |-
+                  From describes the trusted namespaces and kinds that can reference the
+                  resources described in "To". Each entry in this list MUST be considered
+                  to be an additional place that references can be valid from, or to put
+                  this another way, entries MUST be combined using OR.
+
+                  Support: Core
+                items:
+                  description: ReferenceGrantFrom describes trusted namespaces and
+                    kinds.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field.
+
+                        When used to permit a SecretObjectReference:
+
+                        * Gateway
+
+                        When used to permit a BackendObjectReference:
+
+                        * GRPCRoute
+                        * HTTPRoute
+                        * TCPRoute
+                        * TLSRoute
+                        * UDPRoute
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent.
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              to:
+                description: |-
+                  To describes the resources that may be referenced by the resources
+                  described in "From". Each entry in this list MUST be considered to be an
+                  additional place that references can be valid to, or to put this another
+                  way, entries MUST be combined using OR.
+
+                  Support: Core
+                items:
+                  description: |-
+                    ReferenceGrantTo describes what Kinds are allowed as targets of the
+                    references.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field:
+
+                        * Secret when used to permit a SecretObjectReference
+                        * Service when used to permit a BackendObjectReference
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent. When unspecified, this policy
+                        refers to all resources of the specified Group and Kind in the local
+                        namespace.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - from
+            - to
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -10280,6 +15290,7 @@ spec:
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
               to:
                 description: |-
                   To describes the resources that may be referenced by the resources
@@ -10329,6 +15340,7 @@ spec:
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - from
             - to
@@ -10343,3 +15355,2173 @@ status:
     plural: ""
   conditions: null
   storedVersions: null
+---
+#
+# config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  name: tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility
+          in matching streams for a given TLS listener.
+
+          If you need to forward traffic to a single target for a TLS listener, you
+          could choose to use a TCPRoute with a TLS listener.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of SNI hostnames that should match against the
+                  SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed in SNI hostnames per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: Hostnames cannot contain an IP
+                  rule: self.all(h, !isIP(h))
+                - message: Hostnames must be valid based on RFC-1123
+                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                    : true)'
+                - message: Wildcards on hostnames must be the first label, and the
+                    rest of hostname must be valid based on RFC-1123
+                  rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
+                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    : true)'
+              parentRefs:
+                description: |-
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                description: Rules are a list of actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a nonexistent resource or
+                        a Service with no endpoints), the rule performs no forwarding; if no
+                        filters are specified that would result in a response being sent, the
+                        underlying implementation must actively reject request attempts to this
+                        backend, by rejecting the connection. Request rejections must respect
+                        weight; if an invalid backend is requested to have 80% of requests, then
+                        80% of requests must be rejected instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - hostnames
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace to which the controller does not have access.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of TLSRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility
+          in matching streams for a given TLS listener.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of SNI names that should match against the
+                  SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed in SNI names per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and TLSRoute, there
+                  must be at least one intersecting hostname for the TLSRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `test.example.com` and `*.example.com` would both match. On the other
+                    hand, `example.com` and `test.example.net` would not match.
+
+                  If both the Listener and TLSRoute have specified hostnames, any
+                  TLSRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  TLSRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+                  If both the Listener and TLSRoute have specified hostnames, and none
+                  match with the criteria above, then the TLSRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+              parentRefs:
+                description: |-
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                description: Rules are a list of TLS matchers and actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a nonexistent resource or
+                        a Service with no endpoints), the rule performs no forwarding; if no
+                        filters are specified that would result in a response being sent, the
+                        underlying implementation must actively reject request attempts to this
+                        backend, by rejecting the connection. Request rejections must respect
+                        weight; if an invalid backend is requested to have 80% of requests, then
+                        80% of requests must be rejected instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace to which the controller does not have access.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha3 version of TLSRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility
+          in matching streams for a given TLS listener.
+
+          If you need to forward traffic to a single target for a TLS listener, you
+          could choose to use a TCPRoute with a TLS listener.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of SNI hostnames that should match against the
+                  SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed in SNI hostnames per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: Hostnames cannot contain an IP
+                  rule: self.all(h, !isIP(h))
+                - message: Hostnames must be valid based on RFC-1123
+                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                    : true)'
+                - message: Wildcards on hostnames must be the first label, and the
+                    rest of hostname must be valid based on RFC-1123
+                  rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
+                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    : true)'
+              parentRefs:
+                description: |-
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                description: Rules are a list of actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a nonexistent resource or
+                        a Service with no endpoints), the rule performs no forwarding; if no
+                        filters are specified that would result in a response being sent, the
+                        underlying implementation must actively reject request attempts to this
+                        backend, by rejecting the connection. Request rejections must respect
+                        weight; if an invalid backend is requested to have 80% of requests, then
+                        80% of requests must be rejected instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - hostnames
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace to which the controller does not have access.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/standard/gateway.networking.k8s.io_vap_safeupgrades.yaml
+#
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/channel: standard
+  name: "safe-upgrades.gateway.networking.k8s.io"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["*"]
+  validations:
+    - expression: "object.spec.group != 'gateway.networking.k8s.io' || oldObject == null || (
+        has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
+        object.metadata.annotations['gateway.networking.k8s.io/channel'] == 'standard' ) || (
+        oldObject != null && has(oldObject.metadata.annotations) && oldObject.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
+        oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental' )"
+      message: "Installing experimental CRDs on top of standard channel CRDs is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install experimental CRDs on top of standard channel CRDs."
+      reason: Invalid
+    - expression: "object.spec.group != 'gateway.networking.k8s.io' ||
+        (has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/bundle-version') &&
+        !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v1.[0-4].\\\\d+') &&
+        !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v0'))" #TODO Kubernetes 1.37: Migrate to kubernetes semver library
+      message: "Installing CRDs with version before v1.5.0 is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install older versions."
+      reason: Invalid
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/channel: standard
+  name: safe-upgrades.gateway.networking.k8s.io
+spec:
+  policyName: safe-upgrades.gateway.networking.k8s.io
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+    - apiGroups:   ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      resources:   ["customresourcedefinitions"]
+      operations:  ["CREATE", "UPDATE"]

--- a/istio/system/charts/gateway-api-crds/templates/standard-install.yaml
+++ b/istio/system/charts/gateway-api-crds/templates/standard-install.yaml
@@ -26,6 +26,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   labels:
     gateway.networking.k8s.io/policy: Direct
   name: backendtlspolicies.gateway.networking.k8s.io
@@ -1412,6 +1413,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -1931,6 +1933,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: gateways.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -5218,6 +5221,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: grpcroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -7292,6 +7296,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: httproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -14225,6 +14230,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: listenersets.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -15009,6 +15015,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: referencegrants.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -15366,6 +15373,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: tlsroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -17483,6 +17491,7 @@ metadata:
   annotations:
     gateway.networking.k8s.io/bundle-version: v1.5.0-dev
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: "safe-upgrades.gateway.networking.k8s.io"
 spec:
   failurePolicy: Fail
@@ -17515,6 +17524,7 @@ metadata:
   annotations:
     gateway.networking.k8s.io/bundle-version: v1.5.0-dev
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: safe-upgrades.gateway.networking.k8s.io
 spec:
   policyName: safe-upgrades.gateway.networking.k8s.io

--- a/istio/system/terraform/main.tf
+++ b/istio/system/terraform/main.tf
@@ -1,6 +1,6 @@
 locals {
   istio_repo_url     = "https://istio-release.storage.googleapis.com/charts"
-  istio_repo_version = "1.27.0"
+  istio_repo_version = "1.30.2"
 }
 
 resource "kubernetes_namespace" "istio_system" {


### PR DESCRIPTION
## Summary

First of two PRs for the EKS 1.34 upgrade (bead **platform-zxc**). **Merge and apply this one first**, while the cluster is still on Kubernetes 1.33.

**Why:** Istio 1.27.0 supports only Kubernetes 1.29–1.33. The cluster cannot move to 1.34 until the mesh is on a version that supports it. Istio 1.30 supports k8s 1.32–1.36 and has the longest support runway (1.28 EOL 2026-06-28, 1.29 EOL 2026-08-31). k8s 1.33 sits in the overlap of Istio 1.27 and 1.30, so this upgrade is safe to apply on the current cluster.

## Changes

- `istio/system/terraform/main.tf` — `istio_repo_version` 1.27.0 → 1.30.2 (single local drives base / istiod / cni / ztunnel / ingress gateway charts).
- `istio/system/charts/gateway-api-crds/` — vendored Gateway API CRDs **v1.2.1 → v1.5.1** (standard channel). Istio 1.30 reads `TLSRoute`/`ReferenceGrant` from the standard channel (`gateway.networking.k8s.io/v1`); with stale v1.2.1 CRDs those resources become invisible to istiod. v1.5.1 standard now also includes `ListenerSet` and `BackendTLSPolicy`.
  - **CRDs are now managed under `templates/` (not `crds/`)** so `helm upgrade` reconciles them on every `terragrunt apply` — no manual apply step on future bumps. Matches the `prometheus-operator-crds` pattern (`prometheus/terraform/main.tf`) and cert-manager's `installCRDs=true`. Each object carries `helm.sh/resource-policy: keep`, so the CRDs (and the Gateways/HTTPRoutes they back) survive a `helm uninstall`.
- `istio/kiali/terraform/main.tf` — kiali-operator chart v2.2.0 → v2.26.0 to track Istio 1.30 (Kiali 2.4+ is tested against currently-supported Istio releases).

## Apply runbook (operator runs; cluster stays on k8s 1.33)

> **One-time CRD adoption.** ✅ **Already performed on `archegos-dev-eks` (2026-06-28)** — the 5 v1.2.1 CRDs are now labelled/annotated for the `gateway-api-crds` release, so this is a no-op there and step 1 can be skipped. Commands kept for reference / other clusters:
>
> The 5 v1.2.1 CRDs were installed via the old `crds/` path and lacked Helm ownership metadata, so `helm upgrade` would refuse to manage them. They were adopted into the `gateway-api-crds` release (the 3 new v1.5 CRDs are created fresh by Helm and need no adoption):
>
> ```bash
> for name in gatewayclasses gateways httproutes grpcroutes referencegrants; do
>   crd="${name}.gateway.networking.k8s.io"
>   kubectl get crd "$crd" >/dev/null 2>&1 || continue
>   kubectl label  crd "$crd" app.kubernetes.io/managed-by=Helm --overwrite
>   kubectl annotate crd "$crd" \
>     meta.helm.sh/release-name=gateway-api-crds \
>     meta.helm.sh/release-namespace=istio-system --overwrite
> done
> ```

1. Run the one-time adoption above.
2. `cd istio/system && terragrunt plan` — confirm the istio chart releases change (1.27.0 → 1.30.2) and the `gateway-api-crds` release now manages the CRDs (+ the new ListenerSet/BackendTLSPolicy/TLSRoute + admission-policy objects); **no namespace or CRD destroys**.
3. `terragrunt apply` — this upgrades the Gateway API CRDs to v1.5.1 automatically (no manual `kubectl apply`).
4. Review the Istio 1.28/1.29/1.30 upgrade notes for behavior changes affecting the ambient-profile istiod values in `main.tf`.
5. Validate:
   - `kubectl get crd | grep gateway.networking.k8s.io` then `kubectl get crd gateways.gateway.networking.k8s.io -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version}'` → `v1.5.1`.
   - `kubectl -n istio-system get pods` — istiod/cni/ztunnel healthy.
   - `istioctl version` — control plane + data plane on 1.30.2.
   - Sidecar/ambient enrollment on a test workload; existing Gateways/VirtualServices still route (smoke-test an app behind `istio-ingressgateway`).
6. Kiali: `cd istio/kiali && terragrunt plan && terragrunt apply`; confirm the Kiali UI loads and sees the mesh.

## Test plan

- [ ] One-time CRD adoption applied (5 existing CRDs labelled/annotated for Helm)
- [ ] `terragrunt plan` (istio/system) shows chart-version + CRD-management changes, no destroys
- [ ] CRDs report bundle-version v1.5.1 after apply (managed by the `gateway-api-crds` release, no manual `kubectl apply` needed)
- [ ] istiod, istio-cni, ztunnel, ingressgateway healthy after apply
- [ ] Existing mesh traffic still routes
- [ ] Kiali UI healthy on v2.26.0
- [ ] **Do not start the EKS 1.34 PR until the mesh is verified healthy on 1.33**

🤖 Generated with [Claude Code](https://claude.com/claude-code)