### PR TITLE
Upgrade EKS cluster 1.33 -> 1.34 (platform-zxc)

### DIFF
--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -72,10 +72,10 @@ jobs:
             # rendered in full and their CRD YAML is exercised.
             if helm template "$name" "$dir" $vals --include-crds > "/tmp/${name}.rendered.yaml"; then
               # Pin to the cluster's Kubernetes version for deterministic validation aligned
-              # to the target API (eks/cluster: 1.33). CRDs + custom resources (Profile,
+              # to the target API (eks/cluster: 1.34). CRDs + custom resources (Profile,
               # Istio, cert-manager, metacontroller, ...) have no public schema -> skipped;
               # core Kubernetes kinds are strictly validated.
-              if ! kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.33.0 -summary "/tmp/${name}.rendered.yaml"; then
+              if ! kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.34.0 -summary "/tmp/${name}.rendered.yaml"; then
                 echo "kubeconform failed: ${name}"; rc=1
               fi
             else

--- a/common/mocks.hcl
+++ b/common/mocks.hcl
@@ -17,7 +17,7 @@ locals {
 
   eks = {
     cluster_name                       = "mock-cluster-name"
-    cluster_version                    = "1.33"
+    cluster_version                    = "1.34"
     cluster_endpoint                   = "https://mock-cluster-endpoint"
     cluster_certificate_authority_data = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg=="
   }

--- a/eks/cluster/terragrunt.hcl
+++ b/eks/cluster/terragrunt.hcl
@@ -56,7 +56,7 @@ locals {
 
 inputs = {
   name               = "${dependency.account.outputs.resource_prefix}-eks"
-  kubernetes_version = "1.33"
+  kubernetes_version = "1.34"
 
   endpoint_public_access = true
 

--- a/kubeflow/charts/pipelines/templates/deployments.yaml
+++ b/kubeflow/charts/pipelines/templates/deployments.yaml
@@ -196,8 +196,9 @@ spec:
         - configMapRef:
             name: kubeflow-pipelines-profile-controller-env
         # Image must provide a Python interpreter: the command runs `python /hooks/sync.py`.
-        # alpine/k8s bundles aws-cli v1 (Python), so python3 is present. Matches upstream KFP 2.16.1.
-        image: docker.io/alpine/k8s:1.32.3@sha256:eec3541331932d8613ce7b3283508063cba7f704302e9b4eda45e49b38a2a0f9
+        # alpine/k8s bundles aws-cli v1 (Python), so python3 is present. Tag tracks the
+        # cluster's kubectl minor (k8s 1.34) to stay within the supported version skew.
+        image: docker.io/alpine/k8s:1.34.1@sha256:ec714df3813b5405292860f8a1c55c5727bf8c33c88992f1e981efad8065547f
         name: profile-controller
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Second of two PRs for the EKS 1.34 upgrade (bead **platform-zxc**). **Do not merge/apply until the Istio 1.30 PR (#211) is applied and the mesh is verified healthy on k8s 1.33** — Istio 1.27 caps at Kubernetes 1.33.

Bumps the EKS control plane one minor (1.33 → 1.34; EKS cannot skip minors). EKS 1.34 has been GA since 2025-10-06 in all regions.

## Changes

- `eks/cluster/terragrunt.hcl` — `kubernetes_version` 1.33 → 1.34.
- `common/mocks.hcl` — `cluster_version` 1.33 → 1.34 (feeds the CSI addon modules at terragrunt-plan mock time).
- `.github/workflows/helm-validate.yaml` — kubeconform `-kubernetes-version` 1.33.0 → 1.34.0. **Pre-flight deprecation gate:** CI renders + schema-validates every kubeflow chart against the 1.34 API surface, flagging any removed/changed API before the live apply.
- `kubeflow/charts/pipelines/templates/deployments.yaml` — profile-controller image `alpine/k8s:1.32.3` → `1.34.1` (digest re-pinned). At API 1.34, bundled kubectl 1.32 is 2 minors behind (outside the supported ±1 skew); 1.34.1 brings it in line.

Auto-tracking (no edits needed, verify post-apply): AL2023 node group AMIs have no `ami_release_version` pin; addons `vpc-cni`/`kube-proxy`/`coredns`/`eks-pod-identity-agent` are `most_recent = true`; CSI drivers (efs/ebs/fsx) resolve from `cluster_version`.

## Apply runbook (operator runs — control-plane upgrade is a ~20–40 min live op)

1. **Pre-flight:** merge this PR only after CI's helm-validate passes against 1.34. Confirm `kubectl get nodes` all Ready, PDBs sane, note current addon versions.
2. `cd eks/cluster && terragrunt plan` — confirm the diff is the control-plane version bump (+ addon resolutions); **no node group or cluster replacement**.
3. `terragrunt apply` — control plane upgrades to 1.34 first.
4. **Node groups:** the same apply rolls AL2023 groups onto 1.34 AMIs. Watch `kubectl get nodes -w`; nodes drain/replace one group at a time. Confirm the GPU group returns with NVIDIA + FSx taints intact.
5. **Addons:** confirm `vpc-cni`, `kube-proxy`, `coredns`, `eks-pod-identity-agent`, and efs/ebs/fsx CSI drivers are all `ACTIVE` post-apply (`aws eks list-addons` / `describe-addon`).
6. Redeploy the pipelines chart so the profile-controller picks up the 1.34.1 kubectl image.

## Post-upgrade validation

- [ ] `kubectl version` → server 1.34
- [ ] All nodes Ready on 1.34; all addons ACTIVE
- [ ] cert-manager, metacontroller, prometheus-operator (v0.92), oauth2-proxy (v7.15.3), core kubeflow pods healthy (no CrashLoopBackOff)
- [ ] Istio mesh still healthy on 1.34 (1.30 covers 1.32–1.36)
- [ ] Smoke KFP run succeeds end-to-end
- [ ] GPU node group scheduling + FSx mounts working

## Test plan

- [ ] CI helm-validate passes against kubeconform 1.34.0 (fix any flagged removed/changed APIs)
- [ ] `terragrunt plan` shows control-plane bump only, no replacements
- [ ] Post-apply validation checklist above

🤖 Generated with [Claude Code](https://claude.com/claude-code)