### PR TITLE
Bump gateway-api-crds chart version so Terraform applies the CRD upgrade

### DIFF
--- a/istio/system/charts/gateway-api-crds/Chart.yaml
+++ b/istio/system/charts/gateway-api-crds/Chart.yaml
@@ -10,7 +10,8 @@ description: >-
   as prometheus-operator-crds. Each object carries `helm.sh/resource-policy: keep` so the
   CRDs (and their custom resources) survive `helm uninstall`. To bump: replace
   templates/standard-install.yaml with the new release bundle, re-add the keep annotation,
-  and update appVersion.
+  and bump BOTH `version` (so Terraform's helm provider re-applies this local chart — it
+  diffs on chart version, not file contents) and `appVersion` (to track the bundle).
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.5.1"


### PR DESCRIPTION
## Summary

Follow-up to #211. The Istio 1.30 deploy upgraded the mesh (istiod/cni/ztunnel/ingressgateway → 1.30.2) but **silently skipped the Gateway API CRD upgrade** — the `gateway-api-crds` release is still rev 1 / v1.2.1.

**Root cause:** #211 moved the bundle `crds/` → `templates/` and bumped `appVersion`, but left the chart `version` at `1.0.0`. The Terraform helm provider diffs local-path charts on chart **`version`**, not file contents, so it detected no change and never ran `helm upgrade` for that release.

**Observed on `archegos-dev-eks` after the deploy:**
- `gateway-api-crds` release: rev 1, chart 1.0.0, appVersion 1.2.1 (unchanged)
- CRDs still `bundle-version: v1.2.1`, no `helm.sh/resource-policy: keep`
- New v1.5 CRDs `TLSRoute` / `ListenerSet` / `BackendTLSPolicy` and the gateway ValidatingAdmissionPolicy: **absent**

**No active breakage:** istiod 1.30 tolerates the absent optional CRDs and is serving config normally; the mesh is healthy. This just completes the intended CRD state.

## Change

- `istio/system/charts/gateway-api-crds/Chart.yaml` — `version` 1.0.0 → 1.1.0; corrected the bump note to bump **`version`** (not just `appVersion`).

## Apply

After merge, re-apply `istio/system`:
```bash
cd istio/system && terragrunt plan   # expect gateway-api-crds release upgrade only
terragrunt apply
```
The 5 existing CRDs are already adopted into the release (labelled/annotated on 2026-06-28), so the upgrade will adopt + upgrade them to v1.5.1, add the keep annotation, and create the 3 new CRDs + admission-policy objects — no manual `kubectl apply`.

## Verify after apply

- [ ] `kubectl get crd gateways.gateway.networking.k8s.io -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version}'` → `v1.5.1`
- [ ] `tlsroutes` / `listenersets` / `backendtlspolicies` CRDs exist
- [ ] CRDs carry `helm.sh/resource-policy: keep`
- [ ] `gateway-api-crds` helm release at rev 2 / appVersion 1.5.1
- [ ] istiod/ztunnel/ingressgateway still healthy; mesh still routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)