### PR TITLE
Bump pipelines chart version to reconcile stale ml-pipeline DB config

### DIFF
--- a/kubeflow/charts/pipelines/Chart.yaml
+++ b/kubeflow/charts/pipelines/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.16.1
 description: A Helm chart for Kubeflow pipelines
 name: kubeflow-pipelines
 type: application
-version: 1.4.2
+version: 1.4.3


### PR DESCRIPTION
## Summary

Restores KFP pipelines: `ml-pipeline-api-server` is currently down (`CreateContainerConfigError` — `secret "postgres-secret" not found`), surfaced during the EKS 1.34 upgrade.

**Root cause (not the 1.34 upgrade):**
- The live `ml-pipeline` deployment references `postgres-secret` (`DBCONFIG_POSTGRESQLCONFIG_*`), but only `mysql-secret` exists.
- The current chart (`kubeflow/charts/pipelines`, v1.4.2) is **MySQL-only — 0 postgres references**. So the running release is **stale**: the Postgres→MySQL revert edited the templates but left `version: 1.4.2` unchanged, so the Terraform helm provider (which diffs local charts on chart **version**, not file contents) skipped re-applying `kubeflow-pipelines` (still rev 20, last updated 04:19 — the 08:43 EKS deploy never touched it).
- The 1.34 node roll restarted the pod, exposing a latent misconfig the previously-running pod was masking.

Same class of bug as #213 (gateway-api-crds).

## Change

- `kubeflow/charts/pipelines/Chart.yaml` — `version` 1.4.2 → 1.4.3 (no template change). Forces the helm provider to re-apply the already-correct MySQL-only chart.

## After merge (Infra - Deploy)

The deploy re-applies `kubeflow-pipelines`, rolling `ml-pipeline` to a `mysql-secret`-only spec. A manual `kubectl rollout restart` would NOT fix it — the stale spec must be reconciled from the chart.

## Verify

- [ ] `kubeflow-pipelines` helm release advances past rev 20
- [ ] `kubectl get deploy -n kubeflow ml-pipeline -o yaml` has no `postgres-secret` / `DBCONFIG_POSTGRESQLCONFIG_*` refs
- [ ] `ml-pipeline-*` pod is `1/1 Running`
- [ ] Smoke KFP run succeeds end-to-end

## Follow-up

The broader "in-repo chart edits need a version bump or the helm provider skips them" hazard now has two occurrences (#213, this). Worth auditing other local charts (`kubeflow/charts/*`, etc.) for template changes that shipped without a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
