### PR TITLE
Upgrade EKS cluster to Kubernetes 1.35 (platform-xxx)

### DIFF
--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -72,10 +72,10 @@ jobs:
             # rendered in full and their CRD YAML is exercised.
             if helm template "$name" "$dir" $vals --include-crds > "/tmp/${name}.rendered.yaml"; then
               # Pin to the cluster's Kubernetes version for deterministic validation aligned
-              # to the target API (eks/cluster: 1.34). CRDs + custom resources (Profile,
+              # to the target API (eks/cluster: 1.35). CRDs + custom resources (Profile,
               # Istio, cert-manager, metacontroller, ...) have no public schema -> skipped;
               # core Kubernetes kinds are strictly validated.
-              if ! kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.34.0 -summary "/tmp/${name}.rendered.yaml"; then
+              if ! kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.35.0 -summary "/tmp/${name}.rendered.yaml"; then
                 echo "kubeconform failed: ${name}"; rc=1
               fi
             else

--- a/common/mocks.hcl
+++ b/common/mocks.hcl
@@ -17,7 +17,7 @@ locals {
 
   eks = {
     cluster_name                       = "mock-cluster-name"
-    cluster_version                    = "1.34"
+    cluster_version                    = "1.35"
     cluster_endpoint                   = "https://mock-cluster-endpoint"
     cluster_certificate_authority_data = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg=="
   }

--- a/eks/cluster/terragrunt.hcl
+++ b/eks/cluster/terragrunt.hcl
@@ -56,7 +56,7 @@ locals {
 
 inputs = {
   name               = "${dependency.account.outputs.resource_prefix}-eks"
-  kubernetes_version = "1.34"
+  kubernetes_version = "1.35"
 
   endpoint_public_access = true
 

--- a/kubeflow/charts/pipelines/Chart.yaml
+++ b/kubeflow/charts/pipelines/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.16.1
 description: A Helm chart for Kubeflow pipelines
 name: kubeflow-pipelines
 type: application
-version: 1.4.3
+version: 1.4.4

--- a/kubeflow/charts/pipelines/templates/deployments.yaml
+++ b/kubeflow/charts/pipelines/templates/deployments.yaml
@@ -197,8 +197,8 @@ spec:
             name: kubeflow-pipelines-profile-controller-env
         # Image must provide a Python interpreter: the command runs `python /hooks/sync.py`.
         # alpine/k8s bundles aws-cli v1 (Python), so python3 is present. Tag tracks the
-        # cluster's kubectl minor (k8s 1.34) to stay within the supported version skew.
-        image: docker.io/alpine/k8s:1.34.1@sha256:ec714df3813b5405292860f8a1c55c5727bf8c33c88992f1e981efad8065547f
+        # cluster's kubectl minor (k8s 1.35) to stay within the supported version skew.
+        image: docker.io/alpine/k8s:1.35.6@sha256:b7a12c5ddf261994c33d2eaaa06fd69a0803ff6b38683bfa3d30a76dcdf92807
         name: profile-controller
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Bump EKS control plane **1.34 → 1.35** (`eks/cluster/terragrunt.hcl`). AL2023 node groups have no `ami_release_version` pin and addons are `most_recent` → they auto-track. EKS 1.35 is confirmed available in `us-east-1`.
- Bump the version-coupled spots in lockstep: kubeconform pre-upgrade gate → `1.35.0`, `common/mocks.hcl` `cluster_version` → `1.35`, and the profile-controller `alpine/k8s` image → `1.35.6` (pinned by digest) for kubectl skew.
- Bump `kubeflow/charts/pipelines` Chart `version` 1.4.3 → 1.4.4 so the Terraform helm provider actually re-applies the local chart's image change.
- **No Istio change:** Istio 1.30.2 already supports k8s 1.32–1.36, so it covers 1.35 — no mesh or Gateway API bump needed this step.

## Test plan
- [ ] **helm-validate** check green (renders every `kubeflow/charts/**` chart and schema-validates against k8s 1.35.0 — the pre-upgrade API gate). Verified locally with kubeconform v0.6.7: all 8 charts pass.
- [ ] **Infra - Validate & Plan** check green.
- [ ] After merge, **Infra - Deploy** (`infra-apply.yaml`) applies control plane → node groups → addons.
- [ ] Post-deploy: cluster reports `1.35`; nodes `Ready`; vpc-cni/kube-proxy/coredns/pod-identity-agent + EFS/EBS/FSx CSI healthy; istiod/ztunnel/waypoints healthy; cert-manager/metacontroller/prometheus-operator/oauth2-proxy/kubeflow pods healthy.
- [ ] Acceptance: a KFP v2 pipeline runs to **Succeeded**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
