### PR TITLE
fix: redeploy dashboard to surface Model Registry menu link

### DIFF
--- a/kubeflow/charts/kubeflow-dashboard/Chart.yaml
+++ b/kubeflow/charts/kubeflow-dashboard/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.0.0
 description: Kubeflow Central Dashboard
 name: kubeflow-dashboard
 type: application
-version: 1.0.2
+version: 1.0.3


### PR DESCRIPTION
## Summary
- Post-merge fix for #224. The Model Registry menu link was added to the dashboard configmap there, but the `kubeflow-dashboard` chart version (`1.0.2`) collided with a `1.0.2` already deployed on `main` from a prior PR. Helm/terraform saw no version change, so the `infra-apply` for #224 skipped the dashboard upgrade and the link never reached the cluster.
- Bumps the chart to `1.0.3` to force the helm upgrade (the [local-chart version-bump gotcha](https://github.com/archegos-labs/platform)).

## Context / validation
- The `/model-registry/` route is already live: a request through the hub gateway → VirtualService → UI returns **HTTP 200** with the UI shell. This PR only restores the **navigation link** in the Central Dashboard.
- All Hub workloads (registry server, MySQL, UI, catalog server, catalog Postgres) are Running/Ready in `dev`.

## Test plan
- [ ] `infra-apply` on merge upgrades `kubeflow-dashboard` to revision 6 (1.0.3)
- [ ] `kubectl -n kubeflow get cm dashboard-config -o jsonpath='{.data.links}' | grep "Model Registry"` returns the link
- [ ] "Model Registry" appears in the Central Dashboard sidebar (restart the dashboard pod if it caches the configmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)