### PR TITLE
feat(hub): enable Model Catalog UI via custom federated UI image

### DIFF
--- a/kubeflow/charts/kubeflow-hub/Chart.yaml
+++ b/kubeflow/charts/kubeflow-hub/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.3.10
 description: Kubeflow Hub (Model Registry) - registry server + MySQL datastore, web UI, and model catalog
 name: kubeflow-hub
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/kubeflow/charts/kubeflow-hub/templates/model-catalog-deployment.yaml
+++ b/kubeflow/charts/kubeflow-hub/templates/model-catalog-deployment.yaml
@@ -85,6 +85,8 @@ metadata:
     app.kubernetes.io/name: model-catalog
     app.kubernetes.io/component: server
     app.kubernetes.io/part-of: model-catalog
+    # The UI BFF discovers the catalog by Service name + this component label.
+    component: model-catalog
 spec:
   selector:
     app.kubernetes.io/part-of: model-catalog

--- a/kubeflow/charts/kubeflow-hub/values.yaml
+++ b/kubeflow/charts/kubeflow-hub/values.yaml
@@ -23,9 +23,14 @@ registry:
     password: ""
     storage: 10Gi
 
+# Custom UI image built from the v0.3.10 source with the frontend in FEDERATED mode
+# (DEPLOYMENT_MODE=federated, mui-theme) so the Model Catalog + MCP Catalog views render — the
+# stock ghcr.io/kubeflow/hub/ui:v0.3.10 is built DEPLOYMENT_MODE=kubeflow, which hides them, and
+# the mode is baked at build time (webpack), not configurable at runtime. The BFF still runs
+# --deployment-mode=kubeflow (see the deployment) so our kubeflow-userid auth flow is unchanged.
 ui:
-  image: ghcr.io/kubeflow/hub/ui
-  tag: v0.3.10
+  image: 541898866282.dkr.ecr.us-east-1.amazonaws.com/kubeflow/hub/ui
+  tag: v0.3.10-federated
   prefix: /model-registry
 
 catalog:


### PR DESCRIPTION
## Summary
- The Model Catalog (and MCP Catalog) UI is gated to `federated`/`standalone` frontend modes; the stock `ghcr.io/kubeflow/hub/ui:v0.3.10` is built `DEPLOYMENT_MODE=kubeflow` (the mode is baked into the JS bundle at build time, not runtime-configurable), so the catalog nav/routes are hidden.
- Points the Hub UI at a **custom image built from the v0.3.10 source with `DEPLOYMENT_MODE=federated`** (`mui-theme`), pushed to ECR `541898866282.dkr.ecr.us-east-1.amazonaws.com/kubeflow/hub/ui:v0.3.10-federated`.
- The **BFF still runs `--deployment-mode=kubeflow`**, so the `kubeflow-userid` auth flow + per-user SAR are unchanged. Only the frontend bundle changes.
- Adds the `component: model-catalog` label the BFF uses to discover the catalog Service.

## Image provenance
Built locally from `kubeflow/hub` @ v0.3.10 (`87fe087c`) using `clients/ui/Dockerfile`, `--build-arg DEPLOYMENT_MODE=federated --build-arg STYLE_THEME=mui-theme`, `linux/amd64`.

## Known follow-up (validating in dev)
The federated frontend surfaces the catalog nav, but registry/catalog data is looked up in the user-selected (profile) namespace while our shared instances live in `kubeflow`. Making them visible to non-admin profile users likely needs `MANDATORY_NAMESPACE=kubeflow` baked plus a RoleBinding granting read access — confirming empirically in dev before finalizing.

## Test plan
- [ ] infra-apply rolls the UI to the federated image
- [ ] Model Catalog nav appears in the Model Registry UI
- [ ] Registry UI still loads (no federated-mode regression)
- [ ] /api/v1/model_catalog/sources resolves via the BFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)