### PR TITLE
revert(hub): roll UI back to stock image (federated render broken)

### DIFF
--- a/kubeflow/charts/kubeflow-hub/Chart.yaml
+++ b/kubeflow/charts/kubeflow-hub/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.3.10
 description: Kubeflow Hub (Model Registry) - registry server + MySQL datastore, web UI, and model catalog
 name: kubeflow-hub
 type: application
-version: 0.1.1
+version: 0.1.2

--- a/kubeflow/charts/kubeflow-hub/values.yaml
+++ b/kubeflow/charts/kubeflow-hub/values.yaml
@@ -23,14 +23,9 @@ registry:
     password: ""
     storage: 10Gi
 
-# Custom UI image built from the v0.3.10 source with the frontend in FEDERATED mode
-# (DEPLOYMENT_MODE=federated, mui-theme) so the Model Catalog + MCP Catalog views render — the
-# stock ghcr.io/kubeflow/hub/ui:v0.3.10 is built DEPLOYMENT_MODE=kubeflow, which hides them, and
-# the mode is baked at build time (webpack), not configurable at runtime. The BFF still runs
-# --deployment-mode=kubeflow (see the deployment) so our kubeflow-userid auth flow is unchanged.
 ui:
-  image: 541898866282.dkr.ecr.us-east-1.amazonaws.com/kubeflow/hub/ui
-  tag: v0.3.10-federated
+  image: ghcr.io/kubeflow/hub/ui
+  tag: v0.3.10
   prefix: /model-registry
 
 catalog:


### PR DESCRIPTION
## Summary
Reverts the Hub UI image back to the stock `ghcr.io/kubeflow/hub/ui:v0.3.10` (chart bumped `0.1.1 → 0.1.2` so the apply redeploys). The custom `federated` image from #226 renders **blank** when embedded in the Kubeflow Central Dashboard and broke the working Model Registry UI.

## Why the federated image doesn't work here
- The `federated` frontend build serves its assets at `publicPath=/` (it's designed to be the root app on its own host, e.g. ODH). Our UI is mounted behind the gateway at `/model-registry/`, so the bundle reference `/app.bundle.js` 404s and the SPA renders blank. The stock `kubeflow` build serves assets at `/model-registry/...` and works.
- It also uses Module Federation with `publicPath='auto'`, and the catalog/registry data lookups still need namespace pinning + RBAC — compounding blockers. Enabling the catalog UI in our embedded setup is not feasible without patching the upstream build, which is out of scope.

## State
- The live deployment was already rolled back to the stock image to restore the UI; this PR makes that durable (otherwise a future apply would re-deploy the broken federated image).
- The `component: model-catalog` label on the catalog Service is kept (harmless, correct if a viable catalog UI lands later).
- The custom ECR image `kubeflow/hub/ui:v0.3.10-federated` is left in ECR (cheap; can be deleted).

## Follow-up
The Model Catalog backend (server + Postgres + PVC) has no reachable UI. Recommend deciding separately whether to `catalog.enabled=false` and/or file a bead to revisit the catalog UI if upstream makes it embeddable.

## Test plan
- [ ] infra-apply rolls the UI back to ghcr stock image
- [ ] Model Registry UI renders again (not blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)